### PR TITLE
Fix hash calculation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ tree-index = "0.4.0"
 
 [dev-dependencies]
 quickcheck = "0.6.2"
+data-encoding = "2.1.1"

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -159,4 +159,20 @@ mod tests {
       "6fac58578fa385f25a54c0637adaca71fdfddcea885d561f33d80c4487149a14",
     );
   }
+
+  #[test]
+  fn root_hash() {
+    let d1: &[u8] = &[0, 1, 2, 3, 4];
+    let d2: &[u8] = &[42, 43, 44, 45, 46, 47, 48];
+    let node1 = Node::new(0, Hash::from_leaf(d1).as_bytes().to_vec(), d1.len());
+    let node2 = Node::new(1, Hash::from_leaf(d2).as_bytes().to_vec(), d2.len());
+    check_hash(
+      Hash::from_roots(&[&node1, &node2]),
+      "2d117e0bb15c6e5236b6ce764649baed1c41890da901a015341503146cc20bcd",
+    );
+    check_hash(
+      Hash::from_roots(&[&node2, &node1]),
+      "9826c8c2d28fc309cce73a4b6208e83e5e4b0433d2369bfbf8858272153849f1",
+    );
+  }
 }

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -9,12 +9,10 @@ use std::ops::{Deref, DerefMut};
 use storage::Node;
 
 // https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack
-lazy_static! {
-  static ref LEAF_TYPE: &'static [u8] = &[0];
-  static ref PARENT_TYPE: &'static [u8] = &[1];
-  static ref ROOT_TYPE: &'static [u8] = &[2];
-  // static ref HYPERCORE: &'static [u8] = b"hypercore";
-}
+const LEAF_TYPE: [u8; 1] = [0; 1];
+const PARENT_TYPE: [u8; 1] = [1; 1];
+const ROOT_TYPE: [u8; 1] = [2; 1];
+//const HYPERCORE: [u8; 9] = *b"hypercore";
 
 /// `BLAKE2b` hash.
 #[derive(Debug, Clone, PartialEq)]
@@ -29,7 +27,7 @@ impl Hash {
     size.write_u64::<BigEndian>(data.len() as u64).unwrap();
 
     let mut hasher = Blake2b::new(32);
-    hasher.update(*LEAF_TYPE);
+    hasher.update(&LEAF_TYPE);
     hasher.update(&size);
     hasher.update(data);
 
@@ -52,7 +50,7 @@ impl Hash {
       .unwrap();
 
     let mut hasher = Blake2b::new(32);
-    hasher.update(*PARENT_TYPE);
+    hasher.update(&PARENT_TYPE);
     hasher.update(&size);
     hasher.update(node1.hash());
     hasher.update(node2.hash());
@@ -77,7 +75,7 @@ impl Hash {
   // Called `crypto.tree()` in the JS implementation.
   pub fn from_roots(roots: &[impl AsRef<Node>]) -> Self {
     let mut hasher = Blake2b::new(32);
-    hasher.update(*ROOT_TYPE);
+    hasher.update(&ROOT_TYPE);
 
     for node in roots {
       let node = node.as_ref();

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -10,9 +10,9 @@ use storage::Node;
 
 // https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack
 lazy_static! {
-  static ref LEAF_TYPE: &'static [u8] = b"0";
-  static ref PARENT_TYPE: &'static [u8] = b"1";
-  static ref ROOT_TYPE: &'static [u8] = b"2";
+  static ref LEAF_TYPE: &'static [u8] = &[0];
+  static ref PARENT_TYPE: &'static [u8] = &[1];
+  static ref ROOT_TYPE: &'static [u8] = &[2];
   // static ref HYPERCORE: &'static [u8] = b"hypercore";
 }
 
@@ -108,5 +108,33 @@ impl Deref for Hash {
 impl DerefMut for Hash {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.hash
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  extern crate data_encoding;
+  use self::data_encoding::HEXLOWER;
+
+  fn hex_bytes(hex: &str) -> Vec<u8> {
+    HEXLOWER.decode(hex.as_bytes()).unwrap()
+  }
+
+  fn check_hash(hash: Hash, hex: &str) {
+    assert_eq!(hash.as_bytes(), &hex_bytes(hex)[..]);
+  }
+
+  #[test]
+  fn leaf_hash() {
+    check_hash(
+      Hash::from_leaf(&[]),
+      "5187b7a8021bf4f2c004ea3a54cfece1754f11c7624d2363c7f4cf4fddd1441e",
+    );
+    check_hash(
+      Hash::from_leaf(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+      "e1001bb0bb9322b6b202b2f737dc12181b11727168d33ca48ffe361c66cd1abe",
+    );
   }
 }

--- a/src/crypto/merkle.rs
+++ b/src/crypto/merkle.rs
@@ -1,7 +1,5 @@
 use crypto::Hash;
-use merkle_tree_stream::{
-  HashMethods, MerkleTreeStream, Node as NodeTrait, PartialNode,
-};
+use merkle_tree_stream::{HashMethods, MerkleTreeStream, PartialNode};
 use std::rc::Rc;
 use storage::Node;
 
@@ -18,7 +16,7 @@ impl HashMethods for H {
   }
 
   fn parent(&self, left: &Self::Node, right: &Self::Node) -> Self::Hash {
-    Hash::from_hashes(left.hash(), right.hash())
+    Hash::from_hashes(left, right)
   }
 
   fn node(&self, partial: &PartialNode, hash: Self::Hash) -> Self::Node {

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -279,7 +279,7 @@ where
       }
 
       visited.push(top.clone());
-      let hash = Hash::from_hashes(&top.hash, &node.hash);
+      let hash = Hash::from_hashes(&top, &node);
       let len = top.len() + node.len();
       top = Node::new(flat::parent(top.index), hash.as_bytes().into(), len);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 #![cfg_attr(test, deny(warnings))]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate failure;
 
 extern crate blake2_rfc;


### PR DESCRIPTION
This is a 🐛 bug fix.

Hashes in the merkle tree do not match the ones calculated by mafintosh/hypercore.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver changes
Minor because of public api changes
