### PR TITLE
Storage: implement keypair read/write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod proof;
 mod replicate;
 mod storage;
 
-pub use crypto::{generate_keypair, Signature};
+pub use crypto::{generate_keypair, sign, verify, Signature};
 pub use ed25519_dalek::{PublicKey, SecretKey};
 pub use event::Event;
 pub use feed::Feed;

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -115,6 +115,7 @@ fn storage_path<P: AsRef<Path>>(dir: P, s: Store) -> PathBuf {
     Store::Data => "data",
     Store::Bitfield => "bitfield",
     Store::Signatures => "signatures",
+    Store::Keypair => "key",
   };
   dir.as_ref().join(filename)
 }

--- a/tests/feed.rs
+++ b/tests/feed.rs
@@ -128,3 +128,35 @@ fn put() {
     .expect(".proof() index 4, digest 4");
   b.put(4, None, proof).unwrap();
 }
+
+#[test]
+fn create_with_storage() {
+  let storage = Storage::new_memory().unwrap();
+  assert!(
+    Feed::with_storage(storage).is_ok(),
+    "Could not create a feed with a storage."
+  );
+}
+
+#[test]
+fn create_with_stored_public_key() {
+  let mut storage = Storage::new_memory().unwrap();
+  let keypair = generate_keypair();
+  storage.write_public_key(&keypair.public);
+  assert!(
+    Feed::with_storage(storage).is_ok(),
+    "Could not create a feed with a stored public key."
+  );
+}
+
+#[test]
+fn create_with_stored_keys() {
+  let mut storage = Storage::new_memory().unwrap();
+  let keypair = generate_keypair();
+  storage.write_public_key(&keypair.public);
+  storage.write_secret_key(&keypair.secret);
+  assert!(
+    Feed::with_storage(storage).is_ok(),
+    "Could not create a feed with a stored keypair."
+  );
+}

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -1,0 +1,54 @@
+extern crate ed25519_dalek;
+extern crate hypercore;
+
+use ed25519_dalek::PublicKey;
+use hypercore::{generate_keypair, sign, verify, Signature, Storage};
+
+#[test]
+fn should_write_and_read_keypair() {
+  let keypair = generate_keypair();
+  let msg = b"hello";
+  // prepare a signature
+  let sig: Signature = sign(&keypair.public, &keypair.secret, msg);
+
+  let mut storage = Storage::new_memory().unwrap();
+  assert!(
+    storage.write_secret_key(&keypair.secret).is_ok(),
+    "Can not store secret key."
+  );
+  assert!(
+    storage.write_public_key(&keypair.public).is_ok(),
+    "Can not store public key."
+  );
+
+  let read = storage.read_public_key();
+  assert!(read.is_ok(), "Can not read public key");
+  let public_key: PublicKey = read.unwrap();
+  assert!(verify(&public_key, msg, Some(&sig)).is_ok());
+}
+
+#[test]
+fn should_read_partial_keypair() {
+  let keypair = generate_keypair();
+  let mut storage = Storage::new_memory().unwrap();
+  assert!(
+    storage.write_public_key(&keypair.public).is_ok(),
+    "Can not store public key."
+  );
+
+  let partial = storage.read_partial_keypair().unwrap();
+  assert!(partial.secret.is_none(), "A secret key is present");
+}
+
+#[test]
+fn should_read_no_keypair() {
+  let mut storage = Storage::new_memory().unwrap();
+  let partial = storage.read_partial_keypair();
+  assert!(partial.is_none(), "A key is present");
+}
+
+#[test]
+fn should_read_empty_public_key() {
+  let mut storage = Storage::new_memory().unwrap();
+  assert!(storage.read_public_key().is_err());
+}


### PR DESCRIPTION
🙋 feature

I've implemented two new functions: `read_keypair` and `write_keypair` in the Storage implementation. 

As I'm fairly new to rust I have a few unsure things (see comments) and am open to corrections! 

Notable change: I've remove the unimplemented `open_key` method as I guessed that you wanted to do what I did :).

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] valid implementation
- [x] use the new methods in the feed (add a function to `generate and store`?)

## Context
https://github.com/datrs/hypercore/issues/16

## Semver Changes
patch