### PR TITLE
tests/helpers -> tests/common

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,6 +29,6 @@ pub fn copy_keys(
 
       return (public, secret);
     }
-    _ => panic!("<tests/helpers>: Could not access secret key"),
+    _ => panic!("<tests/common>: Could not access secret key"),
   }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,9 +4,7 @@ extern crate random_access_memory as ram;
 extern crate random_access_storage;
 
 use self::failure::Error;
-use self::random_access_storage::RandomAccess;
-use hypercore::{Feed, PublicKey, SecretKey, Storage, Store};
-use std::fmt::Debug;
+use hypercore::{Feed, Storage, Store};
 
 pub fn create_feed(
   page_size: usize,
@@ -14,21 +12,4 @@ pub fn create_feed(
   let create = |_store: Store| Ok(ram::RandomAccessMemory::new(page_size));
   let storage = Storage::new(create)?;
   Ok(Feed::with_storage(storage)?)
-}
-
-pub fn copy_keys(
-  feed: &Feed<impl RandomAccess<Error = Error> + Debug>,
-) -> (PublicKey, SecretKey) {
-  match &feed.secret_key() {
-    Some(secret) => {
-      let secret = secret.to_bytes();
-      let public = &feed.public_key().to_bytes();
-
-      let public = PublicKey::from_bytes(public).unwrap();
-      let secret = SecretKey::from_bytes(&secret).unwrap();
-
-      return (public, secret);
-    }
-    _ => panic!("<tests/common>: Could not access secret key"),
-  }
 }

--- a/tests/feed.rs
+++ b/tests/feed.rs
@@ -4,7 +4,7 @@ extern crate random_access_memory as ram;
 
 mod common;
 
-use common::{copy_keys, create_feed};
+use common::create_feed;
 use hypercore::{generate_keypair, Feed, NodeTrait, Storage};
 
 #[test]
@@ -159,4 +159,21 @@ fn create_with_stored_keys() {
     Feed::with_storage(storage).is_ok(),
     "Could not create a feed with a stored keypair."
   );
+}
+
+fn copy_keys(
+  feed: &Feed<impl RandomAccess<Error = Error> + Debug>,
+) -> (PublicKey, SecretKey) {
+  match &feed.secret_key() {
+    Some(secret) => {
+      let secret = secret.to_bytes();
+      let public = &feed.public_key().to_bytes();
+
+      let public = PublicKey::from_bytes(public).unwrap();
+      let secret = SecretKey::from_bytes(&secret).unwrap();
+
+      return (public, secret);
+    }
+    _ => panic!("<tests/common>: Could not access secret key"),
+  }
 }

--- a/tests/feed.rs
+++ b/tests/feed.rs
@@ -2,9 +2,9 @@ extern crate failure;
 extern crate hypercore;
 extern crate random_access_memory as ram;
 
-mod helpers;
+mod common;
 
-use helpers::{copy_keys, create_feed};
+use common::{copy_keys, create_feed};
 use hypercore::{generate_keypair, Feed, NodeTrait, Storage};
 
 #[test]

--- a/tests/feed.rs
+++ b/tests/feed.rs
@@ -1,11 +1,17 @@
 extern crate failure;
 extern crate hypercore;
 extern crate random_access_memory as ram;
+extern crate random_access_storage;
 
 mod common;
 
+use self::failure::Error;
+use self::random_access_storage::RandomAccess;
 use common::create_feed;
-use hypercore::{generate_keypair, Feed, NodeTrait, Storage};
+use hypercore::{
+  generate_keypair, Feed, NodeTrait, PublicKey, SecretKey, Storage,
+};
+use std::fmt::Debug;
 
 #[test]
 fn create_with_key() {

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -2,9 +2,9 @@
 extern crate quickcheck;
 extern crate hypercore;
 
-mod helpers;
+mod common;
 
-use helpers::create_feed;
+use common::create_feed;
 use quickcheck::{Arbitrary, Gen};
 use std::u8;
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,8 +1,8 @@
 extern crate hypercore;
 
-mod helpers;
+mod common;
 
-use helpers::create_feed;
+use common::create_feed;
 
 // Postmortem: errors were happening correctly, but the error check in
 // `.signature()` was off. Instead of checking for a range (`<`), we were


### PR DESCRIPTION
Renames `tests/helpers` to `tests/common`, as recommended by https://doc.rust-lang.org/book/second-edition/ch11-03-test-organization.html. Minor change, but figured it'd be useful to be consistent :sparkles: