### PR TITLE
[WIP] 🙋FFI bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/datrs/hypercore"
 readme = "README.md"
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 
+[build-dependencies]
+cbindgen = "0.6.3"
+
 [dependencies]
 blake2-rfc = "0.2.18"
 byteorder = "1.2.6"
@@ -32,3 +35,6 @@ quickcheck = "0.7.1"
 data-encoding = "2.1.1"
 remove_dir_all = "0.5.1"
 tempfile = "3.0.4"
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+extern crate cbindgen;
+
+use cbindgen::{Builder, Config};
+use std::env;
+
+fn main() {
+  let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+  let config = Config::from_file("cbindgen.toml")
+    .expect("Failed to read `cbindgen.toml`!");
+
+  cbindgen::Builder::new()
+    .with_crate(crate_dir)
+    .with_config(config)
+    .generate()
+    .expect("Unable to generate bindings")
+    .write_to_file("include/hypercore.h");
+}

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -1,0 +1,9 @@
+header = "/* c bindings to the hypercore library */"
+include_guard = "HYPERCORE_BINDINGS_H"
+language = "C"
+
+#[parse]
+#expand = ["hypercore"]
+
+[enum]
+rename_variants = "QualifiedScreamingSnakeCase"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,14 @@
+use random_access_memory::RandomAccessMemory;
+use {generate_keypair, Feed, Storage};
+
+#[no_mangle]
+pub extern "C" fn new_feed() -> *mut Feed<RandomAccessMemory> {
+  let keypair = generate_keypair();
+  let storage = Storage::new_memory().unwrap();
+  let feed = Feed::builder(keypair.public, storage)
+    .secret_key(keypair.secret)
+    .build()
+    .unwrap();
+
+  Box::into_raw(Box::new(feed)) as *mut Feed<RandomAccessMemory>
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ extern crate sparse_bitfield;
 extern crate tree_index;
 
 pub mod bitfield;
+pub mod ffi;
 pub mod prelude;
 
 mod crypto;


### PR DESCRIPTION
(I'm opening this PR quite early to get more feedback and fix it)

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
As discussed in https://github.com/datrs/hypercore/issues/36, this sets up the FFI infrastructure with `cbindgen`. It is using the [`build.rs`](https://github.com/eqrion/cbindgen#buildrs) way, but many projects define a `Makefile` or some other external way to generate the bindings via the `cbindgen` command line. The reason is that expanding macros might take some time (I even [disabled it](https://github.com/datrs/hypercore/compare/master...luizirber:feature/ffi#diff-abab139d44e8af83aa4842577b23a27dR6) for now), and this ends up being executed every time the crate is built (but the C header rarely changes).

I'm keeping the FFI module inside the `hypercore` repo. Some projects create [another crate for the FFI](https://github.com/flavray/avro-rs-ffi), but I think this is easier to keep in sync.

I set up a [Python project using it](https://github.com/luizirber/hypercore-py
) to help guide what APIs to expose thru the FFI. I was thinking about developing this by:
- Creating a test function in Python, with a Pythonic API
- Implementing the Python side of the FFI and figure out what needs to be called on the Rust FFI
- Implementing the Rust FFI function.

There is only one function for now (and it's not even very useful), but it already works to create a feed on the [Python side](https://github.com/luizirber/hypercore-py/blob/e6d18503e61c67aaaddf7a4558b0958c646bf88f/tests/test_feed.py#L4)

## Semver Changes

No API changes on the Rust side.