### PR TITLE
Stricter lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,14 @@ documentation = "https://docs.rs/hypercore"
 repository = "https://github.com/datrs/hypercore"
 readme = "README.md"
 authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
+keywords = ["dat", "p2p", "stream", "feed", "merkle"]
+categories = [
+  "asynchronous",
+  "concurrency",
+  "cryptography",
+  "data-structures",
+  "encoding",
+]
 
 [dependencies]
 blake2-rfc = "0.2.18"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,49 +1,49 @@
-// #![feature(test)]
+#![feature(test)]
 
-// extern crate failure;
-// extern crate hypercore;
-// extern crate random_access_memory as ram;
+extern crate failure;
+extern crate hypercore;
+extern crate random_access_memory as ram;
 
-// extern crate test;
+extern crate test;
 
-// use self::test::Bencher;
-// use failure::Error;
-// use hypercore::{Feed, Storage, Store};
-// use ram::RandomAccessMemory;
+use self::test::Bencher;
+use failure::Error;
+use hypercore::{Feed, Storage, Store};
+use ram::RandomAccessMemory;
 
-// fn create_feed(page_size: usize) -> Result<Feed<RandomAccessMemory>, Error> {
-//   let create = |_store: Store| Ok(RandomAccessMemory::new(page_size));
-//   let storage = Storage::new(create)?;
-//   Ok(Feed::with_storage(storage)?)
-// }
+fn create_feed(page_size: usize) -> Result<Feed<RandomAccessMemory>, Error> {
+  let create = |_store: Store| Ok(RandomAccessMemory::new(page_size));
+  let storage = Storage::new(create)?;
+  Ok(Feed::with_storage(storage)?)
+}
 
-// #[bench]
-// fn create(b: &mut Bencher) {
-//   b.iter(|| {
-//     create_feed(1024).unwrap();
-//   });
-// }
+#[bench]
+fn create(b: &mut Bencher) {
+  b.iter(|| {
+    create_feed(1024).unwrap();
+  });
+}
 
-// #[bench]
-// fn write(b: &mut Bencher) {
-//   let mut feed = create_feed(1024).unwrap();
-//   let data = Vec::from("hello");
-//   b.iter(|| {
-//     feed.append(&data).unwrap();
-//   });
-// }
+#[bench]
+fn write(b: &mut Bencher) {
+  let mut feed = create_feed(1024).unwrap();
+  let data = Vec::from("hello");
+  b.iter(|| {
+    feed.append(&data).unwrap();
+  });
+}
 
-// #[bench]
-// fn read(b: &mut Bencher) {
-//   let mut feed = create_feed(1024).unwrap();
-//   let data = Vec::from("hello");
-//   for _ in 0..1000 {
-//     feed.append(&data).unwrap();
-//   }
+#[bench]
+fn read(b: &mut Bencher) {
+  let mut feed = create_feed(1024).unwrap();
+  let data = Vec::from("hello");
+  for _ in 0..1000 {
+    feed.append(&data).unwrap();
+  }
 
-//   let mut i = 0;
-//   b.iter(|| {
-//     feed.get(i).unwrap();
-//     i += 1;
-//   });
-// }
+  let mut i = 0;
+  b.iter(|| {
+    feed.get(i).unwrap();
+    i += 1;
+  });
+}

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,49 +1,49 @@
-#![feature(test)]
+// #![feature(test)]
 
-extern crate failure;
-extern crate hypercore;
-extern crate random_access_memory as ram;
+// extern crate failure;
+// extern crate hypercore;
+// extern crate random_access_memory as ram;
 
-extern crate test;
+// extern crate test;
 
-use self::test::Bencher;
-use failure::Error;
-use hypercore::{Feed, Storage, Store};
-use ram::RandomAccessMemory;
+// use self::test::Bencher;
+// use failure::Error;
+// use hypercore::{Feed, Storage, Store};
+// use ram::RandomAccessMemory;
 
-fn create_feed(page_size: usize) -> Result<Feed<RandomAccessMemory>, Error> {
-  let create = |_store: Store| Ok(RandomAccessMemory::new(page_size));
-  let storage = Storage::new(create)?;
-  Ok(Feed::with_storage(storage)?)
-}
+// fn create_feed(page_size: usize) -> Result<Feed<RandomAccessMemory>, Error> {
+//   let create = |_store: Store| Ok(RandomAccessMemory::new(page_size));
+//   let storage = Storage::new(create)?;
+//   Ok(Feed::with_storage(storage)?)
+// }
 
-#[bench]
-fn create(b: &mut Bencher) {
-  b.iter(|| {
-    create_feed(1024).unwrap();
-  });
-}
+// #[bench]
+// fn create(b: &mut Bencher) {
+//   b.iter(|| {
+//     create_feed(1024).unwrap();
+//   });
+// }
 
-#[bench]
-fn write(b: &mut Bencher) {
-  let mut feed = create_feed(1024).unwrap();
-  let data = Vec::from("hello");
-  b.iter(|| {
-    feed.append(&data).unwrap();
-  });
-}
+// #[bench]
+// fn write(b: &mut Bencher) {
+//   let mut feed = create_feed(1024).unwrap();
+//   let data = Vec::from("hello");
+//   b.iter(|| {
+//     feed.append(&data).unwrap();
+//   });
+// }
 
-#[bench]
-fn read(b: &mut Bencher) {
-  let mut feed = create_feed(1024).unwrap();
-  let data = Vec::from("hello");
-  for _ in 0..1000 {
-    feed.append(&data).unwrap();
-  }
+// #[bench]
+// fn read(b: &mut Bencher) {
+//   let mut feed = create_feed(1024).unwrap();
+//   let data = Vec::from("hello");
+//   for _ in 0..1000 {
+//     feed.append(&data).unwrap();
+//   }
 
-  let mut i = 0;
-  b.iter(|| {
-    feed.get(i).unwrap();
-    i += 1;
-  });
-}
+//   let mut i = 0;
+//   b.iter(|| {
+//     feed.get(i).unwrap();
+//     i += 1;
+//   });
+// }

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -3,11 +3,11 @@ pub use blake2_rfc::blake2b::Blake2bResult;
 use blake2_rfc::blake2b::Blake2b;
 use byteorder::{BigEndian, WriteBytesExt};
 // use ed25519_dalek::PublicKey;
+use crate::storage::Node;
 use merkle_tree_stream::Node as NodeTrait;
 use std::convert::AsRef;
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use storage::Node;
 
 // https://en.wikipedia.org/wiki/Merkle_tree#Second_preimage_attack
 const LEAF_TYPE: [u8; 1] = [0x00];

--- a/src/crypto/key_pair.rs
+++ b/src/crypto/key_pair.rs
@@ -2,9 +2,9 @@
 
 pub use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature};
 
+use crate::Result;
 use rand::OsRng;
 use sha2::Sha512;
-use Result;
 
 /// Generate a new `Ed25519` key pair.
 pub fn generate() -> Keypair {

--- a/src/crypto/merkle.rs
+++ b/src/crypto/merkle.rs
@@ -1,7 +1,7 @@
-use crypto::Hash;
+use crate::crypto::Hash;
+use crate::storage::Node;
 use merkle_tree_stream::{HashMethods, MerkleTreeStream, PartialNode};
 use std::rc::Rc;
-use storage::Node;
 
 #[derive(Debug)]
 struct H;

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -1,21 +1,21 @@
 //! Hypercore's main abstraction. Exposes an append-only, secure log structure.
 
-use feed_builder::FeedBuilder;
-use replicate::{Message, Peer};
-pub use storage::{Node, NodeTrait, Storage, Store};
+use crate::feed_builder::FeedBuilder;
+use crate::replicate::{Message, Peer};
+pub use crate::storage::{Node, NodeTrait, Storage, Store};
 
-use bitfield::Bitfield;
-use crypto::{generate_keypair, sign, verify, Hash, Merkle};
+use crate::bitfield::Bitfield;
+use crate::crypto::{generate_keypair, sign, verify, Hash, Merkle};
+use crate::proof::Proof;
+use crate::Result;
 use ed25519_dalek::{PublicKey, SecretKey, Signature};
 use failure::Error;
 use flat_tree as flat;
 use pretty_hash::fmt as pretty_fmt;
-use proof::Proof;
 use random_access_disk::RandomAccessDisk;
 use random_access_memory::RandomAccessMemory;
 use random_access_storage::RandomAccess;
 use tree_index::TreeIndex;
-use Result;
 
 use std::borrow::Borrow;
 use std::cmp;
@@ -50,7 +50,7 @@ where
   T: RandomAccess<Error = Error> + Debug,
 {
   /// Create a new instance with a custom storage backend.
-  pub fn with_storage(mut storage: ::storage::Storage<T>) -> Result<Self> {
+  pub fn with_storage(mut storage: crate::storage::Storage<T>) -> Result<Self> {
     match storage.read_partial_keypair() {
       Some(partial_keypair) => {
         let builder = FeedBuilder::new(partial_keypair.public, storage);
@@ -566,7 +566,7 @@ impl Default for Feed<RandomAccessMemory> {
 }
 
 impl<T: RandomAccess<Error = Error> + Debug> Display for Feed<T> {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     // TODO: yay, we should find a way to convert this .unwrap() to an error
     // type that's accepted by `fmt::Result<(), fmt::Error>`.
     let key = pretty_fmt(&self.public_key.to_bytes()).unwrap();

--- a/src/feed_builder.rs
+++ b/src/feed_builder.rs
@@ -1,15 +1,15 @@
 use ed25519_dalek::{PublicKey, SecretKey};
 
-use bitfield::Bitfield;
-use crypto::Merkle;
+use crate::bitfield::Bitfield;
+use crate::crypto::Merkle;
+use crate::storage::Storage;
 use failure::Error;
 use random_access_storage::RandomAccess;
 use std::fmt::Debug;
-use storage::Storage;
 use tree_index::TreeIndex;
 
-use Feed;
-use Result;
+use crate::Feed;
+use crate::Result;
 
 /// Construct a new `Feed` instance.
 // TODO: make this an actual builder pattern.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#![forbid(unsafe_code, missing_debug_implementations, missing_docs)]
+#![forbid(unsafe_code, bad_style, future_incompatible)]
+#![forbid(rust_2018_idioms, rust_2018_compatibility)]
+#![forbid(missing_debug_implementations)]
+#![forbid(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
 //! ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,14 +50,14 @@ mod proof;
 mod replicate;
 mod storage;
 
-pub use crypto::{generate_keypair, sign, verify, Signature};
+pub use crate::crypto::{generate_keypair, sign, verify, Signature};
+pub use crate::event::Event;
+pub use crate::feed::Feed;
+pub use crate::feed_builder::FeedBuilder;
+pub use crate::proof::Proof;
+pub use crate::replicate::Peer;
+pub use crate::storage::{Node, NodeTrait, Storage, Store};
 pub use ed25519_dalek::{PublicKey, SecretKey};
-pub use event::Event;
-pub use feed::Feed;
-pub use feed_builder::FeedBuilder;
-pub use proof::Proof;
-pub use replicate::Peer;
-pub use storage::{Node, NodeTrait, Storage, Store};
 
 use failure::Error;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,6 @@
 //!   let feed = Feed::default();
 //! }
 //! ```
-pub use feed::Feed;
+pub use crate::feed::Feed;
 // pub use feed_builder::FeedBuilder;
-pub use storage::{Node, NodeTrait, Storage, Store};
+pub use crate::storage::{Node, NodeTrait, Storage, Store};

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,5 +1,5 @@
-use Node;
-use Signature;
+use crate::Node;
+use crate::Signature;
 
 /// A merkle proof for an index, created by the `.proof()` method.
 #[derive(Debug, PartialEq, Clone)]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,6 +7,7 @@ pub use self::node::Node;
 pub use self::persist::Persist;
 pub use merkle_tree_stream::Node as NodeTrait;
 
+use crate::Result;
 use ed25519_dalek::{
   PublicKey, SecretKey, Signature, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH,
 };
@@ -20,7 +21,6 @@ use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::path::PathBuf;
-use Result;
 
 const HEADER_OFFSET: usize = 32;
 

--- a/src/storage/node.rs
+++ b/src/storage/node.rs
@@ -1,11 +1,11 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use crate::Result;
 use flat_tree;
 use merkle_tree_stream::Node as NodeTrait;
 use pretty_hash::fmt as pretty_fmt;
 use std::convert::AsRef;
 use std::fmt::{self, Display};
 use std::io::Cursor;
-use Result;
 
 /// Nodes that are persisted to disk.
 // TODO: derive Ord, PartialOrd based on index.
@@ -105,7 +105,7 @@ impl AsRef<Node> for Node {
 }
 
 impl Display for Node {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(
       f,
       "Node {{ index: {}, hash: {}, length: {} }}",

--- a/src/storage/persist.rs
+++ b/src/storage/persist.rs
@@ -1,7 +1,7 @@
 use super::Storage;
+use crate::Result;
 use random_access_storage::RandomAccess;
 use std::fmt::Debug;
-use Result;
 
 /// Persist data to a `Storage` instance.
 pub trait Persist<T>


### PR DESCRIPTION
Enabled stricter lints at the entry file (`lib.rs`), and ran `cargo fix` to fix all incompatibilities, prepping us for the upcoming 2018 release of Rust. Also added categories to `Cargo.toml` for better SEO. Thanks!