### PR TITLE
use tree_index functions

### DIFF
--- a/src/bitfield/mod.rs
+++ b/src/bitfield/mod.rs
@@ -155,10 +155,10 @@ impl Bitfield {
     let o = index & 3;
     index = (index - o) / 4;
 
-    let start = 2 * index;
+    let start = tree_index(index);
 
     let left = self.index.get_byte(start) & self.masks.index_update[o];
-    let right = get_index_value(value) >> (2 * o);
+    let right = get_index_value(value) >> tree_index(o);
     let mut byte = left | right;
     let len = self.index.len();
     let max_len = self.page_len * 256;
@@ -198,7 +198,7 @@ impl Bitfield {
 
   fn expand(&mut self, len: usize) {
     let mut roots = vec![]; // FIXME: alloc.
-    flat_tree::full_roots(2 * len, &mut roots);
+    flat_tree::full_roots(tree_index(len), &mut roots);
     let bf = &mut self.index;
     let ite = &mut self.iterator;
     let masks = &self.masks;
@@ -251,4 +251,10 @@ fn get_index_value(index: u8) -> u8 {
 #[inline]
 fn mask_8b(num: usize) -> usize {
   num & 7
+}
+
+/// Convert the index to the index in the tree.
+#[inline]
+fn tree_index(index: usize) -> usize {
+  2 * index
 }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -129,7 +129,7 @@ where
     self.byte_length += offset;
 
     self.bitfield.set(self.length, true);
-    self.tree.set(2 * self.length);
+    self.tree.set(tree_index(self.length));
     self.length += 1;
 
     Ok(())
@@ -192,7 +192,7 @@ where
     let mut nodes = vec![];
 
     let proof = self.tree.proof_with_digest(
-      2 * index,
+      tree_index(index),
       digest,
       include_hash,
       &mut nodes,
@@ -230,7 +230,7 @@ where
 
   /// Compute the digest for the index.
   pub fn digest(&mut self, index: usize) -> usize {
-    self.tree.digest(2 * index)
+    self.tree.digest(tree_index(index))
   }
 
   /// Insert data into the tree at `index`. Verifies the `proof` when inserting
@@ -242,7 +242,7 @@ where
     data: Option<&[u8]>,
     mut proof: Proof,
   ) -> Result<()> {
-    let mut next = 2 * index;
+    let mut next = tree_index(index);
     let mut trusted: Option<usize> = None;
     let mut missing = vec![];
 
@@ -287,7 +287,7 @@ where
     let mut visited = vec![];
     let mut top = match data {
       Some(data) => Node::new(
-        2 * index,
+        tree_index(index),
         Hash::from_leaf(&data).as_bytes().to_owned(),
         data.len(),
       ),
@@ -371,7 +371,7 @@ where
       self.tree.set(node.index);
     }
 
-    self.tree.set(2 * index);
+    self.tree.set(tree_index(index));
 
     if let Some(_data) = data {
       if self.bitfield.set(index, true).is_changed() {
@@ -443,7 +443,7 @@ where
       index <= self.length,
       format!("Root index bounds exceeded {} > {}", index, self.length)
     );
-    let roots_index = index * 2 + 2;
+    let roots_index = tree_index(index) + 2;
     let mut indexes = vec![];
     flat::full_roots(roots_index, &mut indexes);
 
@@ -579,4 +579,10 @@ impl<T: RandomAccess<Error = Error> + Debug> Display for Feed<T> {
       key, len, byte_len, peers
     )
   }
+}
+
+/// Convert the index to the index in the tree.
+#[inline]
+fn tree_index(index: usize) -> usize {
+  2 * index
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -178,11 +178,11 @@ where
     cached_nodes: &[Node],
   ) -> Result<Range<usize>> {
     let mut roots = Vec::new(); // TODO: reuse alloc
-    flat::full_roots(2 * index, &mut roots);
+    flat::full_roots(tree_index(index), &mut roots);
 
     let mut offset = 0;
     let mut pending = roots.len();
-    let block_index = 2 * index;
+    let block_index = tree_index(index);
 
     if pending == 0 {
       let len = match find_node(&cached_nodes, block_index) {
@@ -336,6 +336,12 @@ fn not_zeroes(bytes: &[u8]) -> bool {
     }
   }
   false
+}
+
+/// Convert the index to the index in the tree.
+#[inline]
+fn tree_index(index: usize) -> usize {
+  2 * index
 }
 
 #[test]


### PR DESCRIPTION
Replaces ad-hoc conversions from `index` to index into `flat-tree` to use inline functions instead. This hopefully makes the code a bit more clear as to what's going on, and will help with future refactoring. Thanks!