### PR TITLE
document src/lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! Hypercore is a secure, distributed append-only log. Built for sharing
 //! large datasets and streams of real time data as part of the [Dat] project. 
 //! This is a rust port of [the original node version][dat-node]
-//! aiming for interoperability. The primary way to use this crate is with the [Feed] struct.
+//! aiming for interoperability. The primary way to use this crate is through the [Feed] struct.
 //!
 //!
 //! ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 //! ## Introduction
 //! Hypercore is a secure, distributed append-only log. Built for sharing
-//! large datasets and streams of real time data as part of the [Dat] project. 
+//! large datasets and streams of real time data as part of the [Dat] project.
 //! This is a rust port of [the original node version][dat-node]
 //! aiming for interoperability. The primary way to use this crate is through the [Feed] struct.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,13 @@
 #![forbid(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 
+//! ## Introduction
+//! Hypercore is a secure, distributed append-only log. Built for sharing
+//! large datasets and streams of real time data as part of the [Dat] project. 
+//! This is a rust port of [the original node version][dat-node]
+//! aiming for interoperability. The primary way to use this crate is with the [Feed] struct.
+//!
+//!
 //! ## Example
 //! ```rust
 //! extern crate hypercore;
@@ -20,6 +27,10 @@
 //! println!("{:?}", feed.get(0)); // prints "hello"
 //! println!("{:?}", feed.get(1)); // prints "world"
 //! ```
+//!
+//! [dat-node]: https://github.com/mafintosh/hypercore
+//! [Dat]: https://github.com/datrs
+//! [Feed]: crate::feed::Feed
 
 #[macro_use]
 extern crate failure;


### PR DESCRIPTION
🔦 documentation change

adds additional documentation to the root of the crate, making it easier for first-time users to use the library.
 
line `33` uses a markdown link syntax that lets you create links using rust's module syntax. This is available on nightly rust only, which docs.rs uses to build docs, but I understand if you don't want to use a nightly feature.

