### PR TITLE
Properly check that result is an error

### DIFF
--- a/src/crypto/key_pair.rs
+++ b/src/crypto/key_pair.rs
@@ -45,5 +45,5 @@ fn can_verify_messages() {
   let from = b"hello";
   let sig = sign(&keypair.public, &keypair.secret, from);
   verify(&keypair.public, from, Some(&sig)).unwrap();
-  verify(&keypair.public, b"oops", Some(&sig)).is_err();
+  verify(&keypair.public, b"oops", Some(&sig)).unwrap_err();
 }


### PR DESCRIPTION
Fixes a compile error in one of the tests on current rust nightly (1.36.0):

    error: unused return value of `std::result::Result::<T, E>::is_err` that must be used
      --> src/crypto/key_pair.rs:48:3
       |
    48 |   verify(&keypair.public, b"oops", Some(&sig)).is_err();
       |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
