### PR TITLE
cleanup: use PublicKey, SecretKey, Signature from wrapped crypto module

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -5,5 +5,5 @@ mod key_pair;
 mod merkle;
 
 pub use self::hash::Hash;
-pub use self::key_pair::{generate as generate_keypair, sign, verify, Signature};
+pub use self::key_pair::{generate as generate_keypair, sign, verify, PublicKey, SecretKey, Signature};
 pub use self::merkle::Merkle;

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -6,10 +6,9 @@ pub use crate::storage::{Node, NodeTrait, Storage, Store};
 
 use crate::audit::Audit;
 use crate::bitfield::Bitfield;
-use crate::crypto::{generate_keypair, sign, verify, Hash, Merkle};
+use crate::crypto::{generate_keypair, sign, verify, Hash, Merkle, PublicKey, SecretKey, Signature};
 use crate::proof::Proof;
 use crate::Result;
-use ed25519_dalek::{PublicKey, SecretKey, Signature};
 use failure::Error;
 use flat_tree as flat;
 use pretty_hash::fmt as pretty_fmt;


### PR DESCRIPTION

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context

Instead of using the `ed25519_dalek` directly in `feed.rs`, import it from the `crypto` wrapper. See https://github.com/datrs/hypercore/issues/6

This is still forwarding the type though; to fully complete the task this issue calls for wrapping the type as well.

## Semver Changes
Patch
