### PR TITLE
Compress bitfield and expose it to network code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ sha2 = "0.8.1"
 sleep-parser = "0.8.0"
 sparse-bitfield = "0.11.0"
 tree-index = "0.6.0"
+bitfield-rle = "0.1.1"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/src/bitfield/mod.rs
+++ b/src/bitfield/mod.rs
@@ -232,6 +232,8 @@ impl Bitfield {
     // TODO: use the index to speed this up *a lot*
     /// https://github.com/mafintosh/hypercore/blob/06f3a1f573cb74ee8cfab2742455318fbf7cc3a2/lib/bitfield.js#L111-L126
     pub fn compress(&self, start: usize, length: usize) -> std::io::Result<Vec<u8>> {
+        // On Node versions this fields might not be present on the want/request message
+        // When both start and length are not present (!0 in node is false), return all data bytes encoded
         if start == 0 && length == 0 {
             return Ok(bitfield_rle::encode(&self.data.to_bytes()?));
         }

--- a/src/bitfield/mod.rs
+++ b/src/bitfield/mod.rs
@@ -240,8 +240,8 @@ impl Bitfield {
         let mut buf = Cursor::new(Vec::with_capacity(length));
 
         let page_size = self.data.page_size() as f64;
-        let mut p = start as f64 / page_size / 8_f64;
-        let end = p + length as f64 / page_size / 8_f64;
+        let mut p = start as f64 / page_size / 8.0;
+        let end = p + length as f64 / page_size / 8.0;
         let offset = p * page_size;
 
         while p < end {
@@ -253,7 +253,7 @@ impl Bitfield {
                     buf.write_all(&page)?;
                 }
             }
-            p += 1_f64;
+            p += 1.0;
         }
 
         Ok(bitfield_rle::encode(&buf.into_inner()))

--- a/src/bitfield/mod.rs
+++ b/src/bitfield/mod.rs
@@ -248,7 +248,7 @@ impl Bitfield {
             let index = p as usize;
             let page = self.data.pages.get(index);
             if let Some(page) = page {
-                if dbg!(page.len()) != 0 {
+                if page.len() != 0 {
                     buf.set_position((p * page_size - offset) as u64);
                     buf.write_all(&page)?;
                 }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -524,6 +524,11 @@ where
         })
     }
 
+    /// Expose the bitfield attribute to use on during download
+    pub fn bitfield(&self) -> &Bitfield {
+        &self.bitfield
+    }
+
     /// (unimplemented) Provide a range of data to download.
     pub fn download(&mut self, _range: Range<u64>) -> Result<()> {
         unimplemented!();

--- a/tests/bitfield.rs
+++ b/tests/bitfield.rs
@@ -183,36 +183,16 @@ fn bitfield_compress() {
     b.set(1, true);
     assert_eq!(b.compress(0, 0).unwrap(), vec![2, 64, 253, 31]);
 
-    for i in 0..32 {
-        b.set(i, true);
-    }
-
-    for i in 64..1024 {
-        b.set(i, true);
-    }
-
-    for i in 1024..1028 {
-        b.set(i, true);
-    }
-
+    b.set(1_424_244, true);
     assert_eq!(
         b.compress(0, 0).unwrap(),
-        vec![19, 17, 227, 3, 2, 240, 253, 27]
+        vec![2, 64, 181, 187, 43, 2, 8, 197, 4]
     );
+    assert_eq!(b.compress(0, 1).unwrap(), vec![2, 64, 253, 31]);
     assert_eq!(
-        b.compress(0, 1).unwrap(),
-        vec![19, 17, 227, 3, 2, 240, 253, 27]
+        b.compress(1_424_244, 1).unwrap(),
+        vec![185, 27, 2, 8, 197, 4]
     );
-    assert_eq!(
-        b.compress(0, 32).unwrap(),
-        vec![19, 17, 227, 3, 2, 240, 253, 27]
-    );
-    assert_eq!(
-        b.compress(0, 1024).unwrap(),
-        vec![19, 17, 227, 3, 2, 240, 253, 27]
-    );
-    assert_eq!(
-        b.compress(1024, 2048).unwrap(),
-        vec![19, 17, 227, 3, 2, 240, 253, 27]
-    );
+
+    assert_eq!(b.compress(1_424_244_000, 1).unwrap(), vec![0]);
 }

--- a/tests/bitfield.rs
+++ b/tests/bitfield.rs
@@ -174,3 +174,22 @@ fn bitfield_dedup() {
     assert!(!b.get(8 * 1024));
     assert!(b.get(16 * 1024));
 }
+
+#[test]
+fn bitfield_compress() {
+    let mut b = Bitfield::new();
+    assert_eq!(b.compress(0, 0).unwrap(), vec![]);
+
+    b.set(1, true);
+    assert_eq!(b.compress(0, 0).unwrap(), vec![2, 64]);
+
+    for i in 0..32 {
+        b.set(i, true);
+    }
+    assert_eq!(b.compress(0, 0).unwrap(), vec![19]);
+    assert_eq!(b.compress(0, 1).unwrap(), vec![7]);
+    assert_eq!(b.compress(0, 2).unwrap(), vec![11]);
+    assert_eq!(b.compress(0, 3).unwrap(), vec![15]);
+    assert_eq!(b.compress(0, 4).unwrap(), vec![19]);
+    assert_eq!(b.compress(0, 5).unwrap(), vec![19]);
+}

--- a/tests/bitfield.rs
+++ b/tests/bitfield.rs
@@ -178,18 +178,41 @@ fn bitfield_dedup() {
 #[test]
 fn bitfield_compress() {
     let mut b = Bitfield::new();
-    assert_eq!(b.compress(0, 0).unwrap(), vec![]);
+    assert_eq!(b.compress(0, 0).unwrap(), vec![0]);
 
     b.set(1, true);
-    assert_eq!(b.compress(0, 0).unwrap(), vec![2, 64]);
+    assert_eq!(b.compress(0, 0).unwrap(), vec![2, 64, 253, 31]);
 
     for i in 0..32 {
         b.set(i, true);
     }
-    assert_eq!(b.compress(0, 0).unwrap(), vec![19]);
-    assert_eq!(b.compress(0, 1).unwrap(), vec![7]);
-    assert_eq!(b.compress(0, 2).unwrap(), vec![11]);
-    assert_eq!(b.compress(0, 3).unwrap(), vec![15]);
-    assert_eq!(b.compress(0, 4).unwrap(), vec![19]);
-    assert_eq!(b.compress(0, 5).unwrap(), vec![19]);
+
+    for i in 64..1024 {
+        b.set(i, true);
+    }
+
+    for i in 1024..1028 {
+        b.set(i, true);
+    }
+
+    assert_eq!(
+        b.compress(0, 0).unwrap(),
+        vec![19, 17, 227, 3, 2, 240, 253, 27]
+    );
+    assert_eq!(
+        b.compress(0, 1).unwrap(),
+        vec![19, 17, 227, 3, 2, 240, 253, 27]
+    );
+    assert_eq!(
+        b.compress(0, 32).unwrap(),
+        vec![19, 17, 227, 3, 2, 240, 253, 27]
+    );
+    assert_eq!(
+        b.compress(0, 1024).unwrap(),
+        vec![19, 17, 227, 3, 2, 240, 253, 27]
+    );
+    assert_eq!(
+        b.compress(1024, 2048).unwrap(),
+        vec![19, 17, 227, 3, 2, 240, 253, 27]
+    );
 }

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,12 +1,7 @@
-#[macro_use]
-extern crate quickcheck;
-extern crate hypercore;
-extern crate rand;
-
 mod common;
 
 use common::create_feed;
-use quickcheck::{Arbitrary, Gen};
+use quickcheck::{quickcheck, Arbitrary, Gen};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::u8;


### PR DESCRIPTION
The network code requires to send compressed bitfields to the wire with the size of the feed.
This commit exposes the bitfield as a public method, and adds the compress method.

bitfield_rle is not encoding the same as node's version.
Tests are broken because of that.

This is a draft while working on other codes, so I can pull from other machines. After that, I will cleanup the changes to have it easier to review, depending on less PRs.

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** a 🙋 feature

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->

## Semver Changes
<!-- Which semantic version change would you recommend? -->
minor
