### PR TITLE
bugfix: fixed skewed range in put_data of Storage

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -107,10 +107,10 @@ where
             return Ok(());
         }
 
-        let mut range = self.data_offset(index, nodes)?;
+        let range = self.data_offset(index, nodes)?;
 
         ensure!(
-            range.by_ref().count() == data.len(),
+            (range.end - range.start) as usize == data.len(),
             format!("length  `{:?} != {:?}`", range.count(), data.len())
         );
 


### PR DESCRIPTION
This is a bug fix:

`ensure!` macro was mutating the range so by the end of the macro evaluation
the range was in wrong state

## Checklist
- [x] tests pass
- [ ] tests and/or benchmarks are included (im not sure how to test this)
- [ ] documentation is changed or added (is this needed?)

## Context
this fixes test in #108 if my comment in that PR is addressed

## Semver Changes
no changes? idk :man_shrugging: 
