### PR TITLE
Emit Download and Append events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tree-index = "0.6.0"
 bitfield-rle = "0.2.0"
 futures = "0.3.4"
 async-std = "1.5.0"
+async-trait = "0.1.30"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,12 +7,9 @@ use test::Bencher;
 
 use hypercore::{Feed, Storage};
 
-async fn create_feed(page_size: usize) -> Result<Feed<RandomAccessMemory>, Error> {
-    let storage = Storage::new(
-        |_| Box::pin(async move { Ok(RandomAccessMemory::new(page_size)) }),
-        true,
-    )
-    .await?;
+async fn create_feed(page_size: usize) -> Result<Feed, Error> {
+    let storage =
+        Storage::new(|_| Box::pin(async move { Ok(RandomAccessMemory::new(page_size)) })).await?;
     Feed::with_storage(storage).await
 }
 

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,27 +1,18 @@
 use async_std::task;
 use hypercore::Feed;
-use random_access_storage::RandomAccess;
-use std::fmt::Debug;
 
-async fn append<T>(feed: &mut Feed<T>, content: &[u8])
-where
-    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
-{
+async fn append(feed: &mut Feed, content: &[u8]) {
     feed.append(content).await.unwrap();
 }
 
-async fn print<T>(feed: &mut Feed<T>)
-where
-    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
-{
+async fn print(feed: &mut Feed) {
     println!("{:?}", feed.get(0).await);
     println!("{:?}", feed.get(1).await);
 }
 
 fn main() {
     task::block_on(task::spawn(async {
-        let mut feed = Feed::default();
-
+        let mut feed = Feed::open_in_memory().await.unwrap();
         append(&mut feed, b"hello").await;
         append(&mut feed, b"world").await;
         print(&mut feed).await;

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,6 @@
 /// An event emitted by a Feed.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Event {
     /// A new block has been appended.
     Append,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,3 +1,8 @@
-/// Events emitted.
+/// An event emitted by a Feed.
 #[derive(Debug, Clone, PartialEq)]
-pub enum Event {}
+pub enum Event {
+    /// A new block has been appended.
+    Append,
+    /// A new block has been downloaded.
+    Download(u64),
+}

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -200,7 +200,7 @@ impl Feed {
     }
 
     /// Emit an event on the feed.
-    async fn emit(&self, event: Event) {
+    async fn emit(&mut self, event: Event) {
         for mut sender in self.subscribers.iter() {
             sender.send(event.clone()).await.unwrap();
         }

--- a/src/feed.rs
+++ b/src/feed.rs
@@ -2,7 +2,9 @@
 
 use crate::feed_builder::FeedBuilder;
 use crate::replicate::{Message, Peer};
-pub use crate::storage::{Node, NodeTrait, Storage, Store};
+pub use crate::storage::{
+    storage_disk, storage_memory, BoxStorage, Node, NodeTrait, Storage, Store,
+};
 
 use crate::audit::Audit;
 use crate::bitfield::Bitfield;
@@ -13,12 +15,8 @@ use crate::proof::Proof;
 use anyhow::{bail, ensure, Result};
 use flat_tree as flat;
 use pretty_hash::fmt as pretty_fmt;
-use random_access_disk::RandomAccessDisk;
-use random_access_memory::RandomAccessMemory;
-use random_access_storage::RandomAccess;
 use tree_index::TreeIndex;
 
-use std::borrow::Borrow;
 use std::cmp;
 use std::fmt::{self, Debug, Display};
 use std::ops::Range;
@@ -55,15 +53,12 @@ use std::sync::Arc;
 /// [builder]: crate::feed_builder::FeedBuilder
 /// [with_storage]: crate::feed::Feed::with_storage
 #[derive(Debug)]
-pub struct Feed<T>
-where
-    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug,
-{
+pub struct Feed {
     /// Merkle tree instance.
     pub(crate) merkle: Merkle,
     pub(crate) public_key: PublicKey,
     pub(crate) secret_key: Option<SecretKey>,
-    pub(crate) storage: Storage<T>,
+    pub(crate) storage: BoxStorage,
     /// Total length of raw data stored in bytes.
     pub(crate) byte_length: u64,
     /// Total number of entries stored in the `Feed`
@@ -74,12 +69,9 @@ where
     pub(crate) peers: Vec<Peer>,
 }
 
-impl<T> Feed<T>
-where
-    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
-{
+impl Feed {
     /// Create a new instance with a custom storage backend.
-    pub async fn with_storage(mut storage: crate::storage::Storage<T>) -> Result<Self> {
+    pub async fn with_storage(mut storage: BoxStorage) -> Result<Self> {
         match storage.read_partial_keypair().await {
             Some(partial_keypair) => {
                 let builder = FeedBuilder::new(partial_keypair.public, storage);
@@ -113,11 +105,27 @@ where
     }
 
     /// Starts a `FeedBuilder` with the provided `PublicKey` and `Storage`.
-    pub fn builder(public_key: PublicKey, storage: Storage<T>) -> FeedBuilder<T> {
+    pub fn builder(public_key: PublicKey, storage: BoxStorage) -> FeedBuilder {
         FeedBuilder::new(public_key, storage)
     }
 
-    /// Get the number of entries in the feed.
+    /// Create a new instance that persists to disk at the location of `dir`.
+    // TODO: Ensure that dir is always a directory.
+    // NOTE: Should we `mkdirp` here?
+    // NOTE: Should we call these `data.bitfield` / `data.tree`?
+    pub async fn open_from_disk<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let dir = path.as_ref().to_owned();
+        let storage = storage_disk(&dir).await?;
+        Self::with_storage(storage).await
+    }
+
+    /// Create a new in-memory instance.
+    pub async fn open_in_memory() -> Result<Self> {
+        let storage = storage_memory().await.unwrap();
+        Self::with_storage(storage).await
+    }
+
+    /// Get the amount of entries in the feed.
     #[inline]
     pub fn len(&self) -> u64 {
         self.length
@@ -159,7 +167,7 @@ where
         let index = self.length;
         let message = hash_with_length_as_bytes(hash, index + 1);
         let signature = sign(&self.public_key, key, &message);
-        self.storage.put_signature(index, signature).await?;
+        self.storage.put_signature(index, &signature).await?;
 
         for node in self.merkle.nodes() {
             self.storage.put_node(node).await?;
@@ -397,8 +405,7 @@ where
         }
 
         if let Some(sig) = sig {
-            let sig = sig.borrow();
-            self.storage.put_signature(index, sig).await?;
+            self.storage.put_signature(index, &sig).await?;
         }
 
         for node in nodes {
@@ -603,7 +610,7 @@ where
     }
 }
 
-impl Feed<RandomAccessDisk> {
+impl Feed {
     /// Create a new instance that persists to disk at the location of `dir`.
     /// If dir was not there, it will be created.
     // NOTE: Should we call these `data.bitfield` / `data.tree`?
@@ -618,7 +625,7 @@ impl Feed<RandomAccessDisk> {
 
         let dir = path.as_ref().to_owned();
 
-        let storage = Storage::new_disk(&dir, false).await?;
+        let storage = storage_disk(&dir).await?;
         Self::with_storage(storage).await
     }
 }
@@ -628,18 +635,13 @@ impl Feed<RandomAccessDisk> {
 /// ## Panics
 /// Can panic if constructing the in-memory store fails, which is highly
 /// unlikely.
-impl Default for Feed<RandomAccessMemory> {
+impl Default for Feed {
     fn default() -> Self {
-        async_std::task::block_on(async {
-            let storage = Storage::new_memory().await.unwrap();
-            Self::with_storage(storage).await.unwrap()
-        })
+        async_std::task::block_on(async { Self::open_in_memory().await.unwrap() })
     }
 }
 
-impl<T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send> Display
-    for Feed<T>
-{
+impl Display for Feed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // TODO: yay, we should find a way to convert this .unwrap() to an error
         // type that's accepted by `fmt::Result<(), fmt::Error>`.

--- a/src/feed_builder.rs
+++ b/src/feed_builder.rs
@@ -2,8 +2,7 @@ use ed25519_dalek::{PublicKey, SecretKey};
 
 use crate::bitfield::Bitfield;
 use crate::crypto::Merkle;
-use crate::storage::Storage;
-use random_access_storage::RandomAccess;
+use crate::storage::BoxStorage;
 use std::fmt::Debug;
 use tree_index::TreeIndex;
 
@@ -14,22 +13,16 @@ use anyhow::Result;
 // TODO: make this an actual builder pattern.
 // https://deterministic.space/elegant-apis-in-rust.html#builder-pattern
 #[derive(Debug)]
-pub struct FeedBuilder<T>
-where
-    T: RandomAccess + Debug,
-{
-    storage: Storage<T>,
+pub struct FeedBuilder {
+    storage: BoxStorage,
     public_key: PublicKey,
     secret_key: Option<SecretKey>,
 }
 
-impl<T> FeedBuilder<T>
-where
-    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
-{
+impl FeedBuilder {
     /// Create a new instance.
     #[inline]
-    pub fn new(public_key: PublicKey, storage: Storage<T>) -> Self {
+    pub fn new(public_key: PublicKey, storage: BoxStorage) -> Self {
         Self {
             storage,
             public_key,
@@ -45,7 +38,7 @@ where
 
     /// Finalize the builder.
     #[inline]
-    pub async fn build(mut self) -> Result<Feed<T>> {
+    pub async fn build(mut self) -> Result<Feed> {
         let (bitfield, tree) = if let Ok(bitfield) = self.storage.read_bitfield().await {
             Bitfield::from_slice(&bitfield)
         } else {

--- a/src/feed_builder.rs
+++ b/src/feed_builder.rs
@@ -77,6 +77,7 @@ impl FeedBuilder {
             secret_key: self.secret_key,
             storage: self.storage,
             peers: vec![],
+            subscribers: vec![],
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,14 +48,12 @@ pub use crate::feed::Feed;
 pub use crate::feed_builder::FeedBuilder;
 pub use crate::proof::Proof;
 pub use crate::replicate::Peer;
-pub use crate::storage::{Node, NodeTrait, Storage, Store};
+pub use crate::storage::{storage_disk, storage_memory, Node, NodeTrait, Storage, Store};
 pub use ed25519_dalek::{PublicKey, SecretKey};
 
 use std::path::Path;
 
 /// Create a new Hypercore `Feed`.
-pub async fn open<P: AsRef<Path>>(
-    path: P,
-) -> anyhow::Result<Feed<random_access_disk::RandomAccessDisk>> {
-    Feed::open(path).await
+pub async fn open<P: AsRef<Path>>(path: P) -> anyhow::Result<Feed> {
+    Feed::open_from_disk(path).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,9 @@ pub use crate::feed::Feed;
 pub use crate::feed_builder::FeedBuilder;
 pub use crate::proof::Proof;
 pub use crate::replicate::Peer;
-pub use crate::storage::{storage_disk, storage_memory, Node, NodeTrait, Storage, Store};
+pub use crate::storage::{
+    storage_disk, storage_memory, BoxStorage, Node, NodeTrait, Storage, Store,
+};
 pub use ed25519_dalek::{PublicKey, SecretKey};
 
 use std::path::Path;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -30,16 +30,16 @@ pub struct PartialKeypair {
 }
 
 /// Dynamic-dispatch Storage wrapper
-pub type BoxStorage = Box<dyn DynStorage>;
+pub type BoxStorage = Box<dyn DynStorage + Send>;
 
 /// Create a new instance backed by a `RandomAccessMemory` instance.
-pub async fn storage_memory() -> Result<Box<dyn DynStorage>> {
+pub async fn storage_memory() -> Result<Box<dyn DynStorage + Send>> {
     let create = |_| async { Ok(RandomAccessMemory::default()) }.boxed();
     Ok(Storage::new(create, false).await?)
 }
 
 /// Create a new instance backed by a `RandomAccessDisk` instance.
-pub async fn storage_disk(dir: &PathBuf) -> Result<Box<dyn DynStorage>> {
+pub async fn storage_disk(dir: &PathBuf) -> Result<Box<dyn DynStorage + Send>> {
     let storage = |storage: Store| {
         let name = match storage {
             Store::Tree => "tree",
@@ -162,7 +162,7 @@ where
     /// storage instances.
     // Named `.open()` in the JS version. Replaces the `.openKey()` method too by
     // requiring a key pair to be initialized before creating a new instance.
-    pub async fn new<Cb>(create: Cb, overwrite: bool) -> Result<Box<dyn DynStorage>>
+    pub async fn new<Cb>(create: Cb, overwrite: bool) -> Result<Box<dyn DynStorage + Send>>
     where
         Cb: Fn(Store) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<T>> + Send>>,
     {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -8,6 +8,7 @@ pub use self::persist::Persist;
 pub use merkle_tree_stream::Node as NodeTrait;
 
 use anyhow::{anyhow, ensure, Result};
+use async_trait::async_trait;
 use ed25519_dalek::{PublicKey, SecretKey, Signature, PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH};
 use flat_tree as flat;
 use futures::future::FutureExt;
@@ -26,6 +27,102 @@ const HEADER_OFFSET: u64 = 32;
 pub struct PartialKeypair {
     pub public: PublicKey,
     pub secret: Option<SecretKey>,
+}
+
+pub type BoxStorage = Box<dyn DynStorage>;
+
+/// Create a new instance backed by a `RandomAccessMemory` instance.
+pub async fn storage_memory() -> Result<Box<dyn DynStorage>> {
+    let create = |_| async { Ok(RandomAccessMemory::default()) }.boxed();
+    Ok(Storage::new(create, false).await?)
+}
+
+/// Create a new instance backed by a `RandomAccessDisk` instance.
+pub async fn storage_disk(dir: &PathBuf) -> Result<Box<dyn DynStorage>> {
+    let storage = |storage: Store| {
+        let name = match storage {
+            Store::Tree => "tree",
+            Store::Data => "data",
+            Store::Bitfield => "bitfield",
+            Store::Signatures => "signatures",
+            Store::Keypair => "key",
+        };
+        RandomAccessDisk::open(dir.as_path().join(name)).boxed()
+    };
+    Ok(Storage::new(storage, false).await?)
+}
+
+#[async_trait]
+pub trait DynStorage: Debug + Send {
+    /// Write data to the feed.
+    async fn write_data(&mut self, offset: u64, data: &[u8]) -> Result<()>;
+
+    /// Write a byte vector to a data storage (random-access instance) at the
+    /// position of `index`.
+    ///
+    /// NOTE: Meant to be called from the `.put()` feed method. Probably used to
+    /// insert data as-is after receiving it from the network (need to confirm
+    /// with mafintosh).
+    /// TODO: Ensure the signature size is correct.
+    /// NOTE: Should we create a `Data` entry type?
+    async fn put_data(&mut self, index: u64, data: &[u8], nodes: &[Node]) -> Result<()>;
+
+    /// Get data from disk that the user has written to it. This is stored
+    /// unencrypted, so there's no decryption needed.
+    // FIXME: data_offset always reads out index 0, length 0
+    async fn get_data(&mut self, index: u64) -> Result<Vec<u8>>;
+
+    /// Search the signature stores for a `Signature`, starting at `index`.
+    fn next_signature<'a>(
+        &'a mut self,
+        index: u64,
+    ) -> futures::future::BoxFuture<'a, Result<Signature>>;
+
+    /// Get a `Signature` from the store.
+    async fn get_signature(&mut self, index: u64) -> Result<Signature>;
+
+    /// Write a `Signature` to `self.Signatures`.
+    /// TODO: Ensure the signature size is correct.
+    /// NOTE: Should we create a `Signature` entry type?
+    async fn put_signature(&mut self, index: u64, signature: &Signature) -> Result<()>;
+
+    /// TODO(yw) docs
+    /// Get the offset for the data, return `(offset, size)`.
+    ///
+    /// ## Panics
+    /// A panic can occur if no maximum value is found.
+    async fn data_offset(&mut self, index: u64, cached_nodes: &[Node]) -> Result<Range<u64>>;
+
+    /// Get a `Node` from the `tree` storage.
+    async fn get_node(&mut self, index: u64) -> Result<Node>;
+
+    /// Write a `Node` to the `tree` storage.
+    /// TODO: prevent extra allocs here. Implement a method on node that can reuse
+    /// a buffer.
+    async fn put_node(&mut self, node: &Node) -> Result<()>;
+
+    /// Write data to the internal bitfield module.
+    /// TODO: Ensure the chunk size is correct.
+    /// NOTE: Should we create a bitfield entry type?
+    async fn put_bitfield(&mut self, offset: u64, data: &[u8]) -> Result<()>;
+
+    /// Read a public key from storage
+    async fn read_public_key(&mut self) -> Result<PublicKey>;
+
+    /// Read a secret key from storage
+    async fn read_secret_key(&mut self) -> Result<SecretKey>;
+
+    /// Write a public key to the storage
+    async fn write_public_key(&mut self, public_key: &PublicKey) -> Result<()>;
+
+    /// Write a secret key to the storage
+    async fn write_secret_key(&mut self, secret_key: &SecretKey) -> Result<()>;
+
+    /// Tries to read a partial keypair (ie: with an optional secret_key) from the storage
+    async fn read_partial_keypair(&mut self) -> Option<PartialKeypair>;
+
+    /// Read bitfield header.
+    async fn read_bitfield(&mut self) -> Result<Vec<u8>>;
 }
 
 /// The types of stores that can be created.
@@ -58,13 +155,13 @@ where
 
 impl<T> Storage<T>
 where
-    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
+    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send + 'static,
 {
     /// Create a new instance. Takes a keypair and a callback to create new
     /// storage instances.
     // Named `.open()` in the JS version. Replaces the `.openKey()` method too by
     // requiring a key pair to be initialized before creating a new instance.
-    pub async fn new<Cb>(create: Cb, overwrite: bool) -> Result<Self>
+    pub async fn new<Cb>(create: Cb, overwrite: bool) -> Result<Box<dyn DynStorage>>
     where
         Cb: Fn(Store) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<T>> + Send>>,
     {
@@ -108,12 +205,18 @@ where
                 .map_err(|e| anyhow!(e))?;
         }
 
-        Ok(instance)
+        Ok(Box::new(instance))
     }
+}
 
+#[async_trait]
+impl<T> DynStorage for Storage<T>
+where
+    T: RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send,
+{
     /// Write data to the feed.
     #[inline]
-    pub async fn write_data(&mut self, offset: u64, data: &[u8]) -> Result<()> {
+    async fn write_data(&mut self, offset: u64, data: &[u8]) -> Result<()> {
         self.data.write(offset, &data).await.map_err(|e| anyhow!(e))
     }
 
@@ -125,7 +228,7 @@ where
     /// with mafintosh).
     /// TODO: Ensure the signature size is correct.
     /// NOTE: Should we create a `Data` entry type?
-    pub async fn put_data(&mut self, index: u64, data: &[u8], nodes: &[Node]) -> Result<()> {
+    async fn put_data(&mut self, index: u64, data: &[u8], nodes: &[Node]) -> Result<()> {
         if data.is_empty() {
             return Ok(());
         }
@@ -147,7 +250,7 @@ where
     /// unencrypted, so there's no decryption needed.
     // FIXME: data_offset always reads out index 0, length 0
     #[inline]
-    pub async fn get_data(&mut self, index: u64) -> Result<Vec<u8>> {
+    async fn get_data(&mut self, index: u64) -> Result<Vec<u8>> {
         let cached_nodes = Vec::new(); // TODO: reuse allocation.
         let range = self.data_offset(index, &cached_nodes).await?;
         self.data
@@ -157,7 +260,7 @@ where
     }
 
     /// Search the signature stores for a `Signature`, starting at `index`.
-    pub fn next_signature<'a>(
+    fn next_signature<'a>(
         &'a mut self,
         index: u64,
     ) -> futures::future::BoxFuture<'a, Result<Signature>> {
@@ -180,7 +283,7 @@ where
 
     /// Get a `Signature` from the store.
     #[inline]
-    pub async fn get_signature(&mut self, index: u64) -> Result<Signature> {
+    async fn get_signature(&mut self, index: u64) -> Result<Signature> {
         let bytes = self
             .signatures
             .read(HEADER_OFFSET + 64 * index, 64)
@@ -194,11 +297,7 @@ where
     /// TODO: Ensure the signature size is correct.
     /// NOTE: Should we create a `Signature` entry type?
     #[inline]
-    pub async fn put_signature(
-        &mut self,
-        index: u64,
-        signature: impl Borrow<Signature>,
-    ) -> Result<()> {
+    async fn put_signature(&mut self, index: u64, signature: &Signature) -> Result<()> {
         let signature = signature.borrow();
         self.signatures
             .write(HEADER_OFFSET + 64 * index, &signature.to_bytes())
@@ -211,7 +310,7 @@ where
     ///
     /// ## Panics
     /// A panic can occur if no maximum value is found.
-    pub async fn data_offset(&mut self, index: u64, cached_nodes: &[Node]) -> Result<Range<u64>> {
+    async fn data_offset(&mut self, index: u64, cached_nodes: &[Node]) -> Result<Range<u64>> {
         let mut roots = Vec::new(); // TODO: reuse alloc
         flat::full_roots(tree_index(index), &mut roots);
 
@@ -258,7 +357,7 @@ where
 
     /// Get a `Node` from the `tree` storage.
     #[inline]
-    pub async fn get_node(&mut self, index: u64) -> Result<Node> {
+    async fn get_node(&mut self, index: u64) -> Result<Node> {
         let buf = self
             .tree
             .read(HEADER_OFFSET + 40 * index, 40)
@@ -272,7 +371,7 @@ where
     /// TODO: prevent extra allocs here. Implement a method on node that can reuse
     /// a buffer.
     #[inline]
-    pub async fn put_node(&mut self, node: &Node) -> Result<()> {
+    async fn put_node(&mut self, node: &Node) -> Result<()> {
         let index = node.index();
         let buf = node.to_bytes()?;
         self.tree
@@ -285,7 +384,7 @@ where
     /// TODO: Ensure the chunk size is correct.
     /// NOTE: Should we create a bitfield entry type?
     #[inline]
-    pub async fn put_bitfield(&mut self, offset: u64, data: &[u8]) -> Result<()> {
+    async fn put_bitfield(&mut self, offset: u64, data: &[u8]) -> Result<()> {
         self.bitfield
             .write(HEADER_OFFSET + offset, data)
             .await
@@ -293,7 +392,7 @@ where
     }
 
     /// Read bitfield header.
-    pub async fn read_bitfield(&mut self) -> Result<Vec<u8>> {
+    async fn read_bitfield(&mut self) -> Result<Vec<u8>> {
         let buf = self
             .bitfield
             .read(0, 32)
@@ -321,7 +420,7 @@ where
     }
 
     /// Read a public key from storage
-    pub async fn read_public_key(&mut self) -> Result<PublicKey> {
+    async fn read_public_key(&mut self) -> Result<PublicKey> {
         let buf = self
             .keypair
             .read(0, PUBLIC_KEY_LENGTH as u64)
@@ -332,7 +431,7 @@ where
     }
 
     /// Read a secret key from storage
-    pub async fn read_secret_key(&mut self) -> Result<SecretKey> {
+    async fn read_secret_key(&mut self) -> Result<SecretKey> {
         let buf = self
             .keypair
             .read(PUBLIC_KEY_LENGTH as u64, SECRET_KEY_LENGTH as u64)
@@ -343,13 +442,13 @@ where
     }
 
     /// Write a public key to the storage
-    pub async fn write_public_key(&mut self, public_key: &PublicKey) -> Result<()> {
+    async fn write_public_key(&mut self, public_key: &PublicKey) -> Result<()> {
         let buf: [u8; PUBLIC_KEY_LENGTH] = public_key.to_bytes();
         self.keypair.write(0, &buf).await.map_err(|e| anyhow!(e))
     }
 
     /// Write a secret key to the storage
-    pub async fn write_secret_key(&mut self, secret_key: &SecretKey) -> Result<()> {
+    async fn write_secret_key(&mut self, secret_key: &SecretKey) -> Result<()> {
         let buf: [u8; SECRET_KEY_LENGTH] = secret_key.to_bytes();
         self.keypair
             .write(PUBLIC_KEY_LENGTH as u64, &buf)
@@ -358,7 +457,7 @@ where
     }
 
     /// Tries to read a partial keypair (ie: with an optional secret_key) from the storage
-    pub async fn read_partial_keypair(&mut self) -> Option<PartialKeypair> {
+    async fn read_partial_keypair(&mut self) -> Option<PartialKeypair> {
         match self.read_public_key().await {
             Ok(public) => match self.read_secret_key().await {
                 Ok(secret) => Some(PartialKeypair {
@@ -372,31 +471,6 @@ where
             },
             Err(_) => None,
         }
-    }
-}
-
-impl Storage<RandomAccessMemory> {
-    /// Create a new instance backed by a `RandomAccessMemory` instance.
-    pub async fn new_memory() -> Result<Self> {
-        let create = |_| async { Ok(RandomAccessMemory::default()) }.boxed();
-        Ok(Self::new(create, true).await?)
-    }
-}
-
-impl Storage<RandomAccessDisk> {
-    /// Create a new instance backed by a `RandomAccessDisk` instance.
-    pub async fn new_disk(dir: &PathBuf, overwrite: bool) -> Result<Self> {
-        let storage = |storage: Store| {
-            let name = match storage {
-                Store::Tree => "tree",
-                Store::Data => "data",
-                Store::Bitfield => "bitfield",
-                Store::Signatures => "signatures",
-                Store::Keypair => "key",
-            };
-            RandomAccessDisk::open(dir.as_path().join(name)).boxed()
-        };
-        Ok(Self::new(storage, overwrite).await?)
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -29,6 +29,7 @@ pub struct PartialKeypair {
     pub secret: Option<SecretKey>,
 }
 
+/// Dynamic-dispatch Storage wrapper
 pub type BoxStorage = Box<dyn DynStorage>;
 
 /// Create a new instance backed by a `RandomAccessMemory` instance.

--- a/src/storage/node.rs
+++ b/src/storage/node.rs
@@ -70,6 +70,13 @@ impl Node {
         writer.write_u64::<BigEndian>(self.length as u64)?;
         Ok(writer)
     }
+
+    // Write into a provided buffer.
+    // pub fn write(&self, buf: &mut [u8]) -> Result<()> {
+    //     buf[0..32].copy_from_slice(&self.hash);
+    //     (&mut buf[32..]).write_u64::<BigEndian>(self.length as u64)?;
+    //     Ok(())
+    // }
 }
 
 impl NodeTrait for Node {

--- a/src/storage/persist.rs
+++ b/src/storage/persist.rs
@@ -1,4 +1,4 @@
-use super::Storage;
+use super::BoxStorage;
 use anyhow::Result;
 use random_access_storage::RandomAccess;
 use std::fmt::Debug;
@@ -15,5 +15,5 @@ where
     fn to_vec(&self) -> Result<Vec<u8>>;
 
     /// Persist into a storage backend.
-    fn store(&self, index: u64, store: Storage<T>) -> Result<()>;
+    fn store(&self, index: u64, store: BoxStorage) -> Result<()>;
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,7 +5,7 @@ use futures::future::FutureExt;
 use hypercore::{Feed, Storage, Store};
 use random_access_memory as ram;
 
-pub async fn create_feed(page_size: usize) -> Result<Feed<ram::RandomAccessMemory>, Error> {
+pub async fn create_feed(page_size: usize) -> Result<Feed, Error> {
     let create = |_store: Store| async move { Ok(ram::RandomAccessMemory::new(page_size)) }.boxed();
     let storage = Storage::new(create, false).await?;
     Feed::with_storage(storage).await

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use data_encoding::HEXLOWER;
 use ed25519_dalek::{Keypair, Signature};
 use hypercore::Feed;
-use hypercore::{Storage, Store};
+use hypercore::{Storage, Store, BoxStorage};
 use random_access_disk::RandomAccessDisk;
 use remove_dir_all::remove_dir_all;
 
@@ -145,7 +145,7 @@ fn storage_path<P: AsRef<Path>>(dir: P, s: Store) -> PathBuf {
     dir.as_ref().join(filename)
 }
 
-async fn mk_storage() -> (PathBuf, Storage<RandomAccessDisk>) {
+async fn mk_storage() -> (PathBuf, BoxStorage) {
     let temp_dir = tempfile::tempdir().unwrap();
     let dir = temp_dir.into_path();
     let storage = Storage::new(

--- a/tests/feed.rs
+++ b/tests/feed.rs
@@ -3,8 +3,7 @@ extern crate random_access_memory as ram;
 mod common;
 
 use common::create_feed;
-use hypercore::{generate_keypair, Event, Feed, NodeTrait, PublicKey, SecretKey, Storage};
-use futures::stream::StreamExt;
+use hypercore::{generate_keypair, Feed, NodeTrait, PublicKey, SecretKey, Storage};
 use hypercore::{storage_disk, storage_memory};
 use std::env::temp_dir;
 use std::fs;
@@ -188,17 +187,7 @@ async fn put_with_data() {
     let mut a = create_feed(50).await.unwrap();
 
     // Create a second feed with the first feed's key.
-<<<<<<< HEAD
-    let (public, secret) = copy_keys(&a);
-    let storage = storage_memory().await.unwrap();
-    let mut b = Feed::builder(public, storage)
-        .secret_key(secret)
-        .build()
-        .await
-        .unwrap();
-=======
     let mut b = create_clone(&a).await.unwrap();
->>>>>>> c79679a... Make dyn storage Send
 
     // Append 4 blocks of data to the writable feed.
     a.append(b"hi").await.unwrap();
@@ -256,7 +245,6 @@ async fn create_with_stored_keys() {
     );
 }
 
-<<<<<<< HEAD
 fn copy_keys(feed: &Feed) -> (PublicKey, SecretKey) {
     match &feed.secret_key() {
         Some(secret) => {
@@ -272,8 +260,6 @@ fn copy_keys(feed: &Feed) -> (PublicKey, SecretKey) {
     }
 }
 
-=======
->>>>>>> c79679a... Make dyn storage Send
 #[async_std::test]
 async fn audit() {
     let mut feed = create_feed(50).await.unwrap();
@@ -367,4 +353,14 @@ async fn try_open_file_as_dir() {
     if Feed::open("Cargo.toml").await.is_ok() {
         panic!("Opening path that points to a file must result in error");
     }
+}
+
+async fn create_clone(feed: &Feed) -> Result<Feed, anyhow::Error> {
+    let (public, secret) = copy_keys(&feed);
+    let storage = storage_memory().await?;
+    let clone = Feed::builder(public, storage)
+        .secret_key(secret)
+        .build()
+        .await?;
+    Ok(clone)
 }

--- a/tests/feed.rs
+++ b/tests/feed.rs
@@ -3,7 +3,7 @@ extern crate random_access_memory as ram;
 mod common;
 
 use common::create_feed;
-use hypercore::{generate_keypair, Feed, NodeTrait, PublicKey, SecretKey, Storage};
+use hypercore::{generate_keypair, storage_disk, Feed, NodeTrait, PublicKey, SecretKey, Storage};
 use random_access_storage::RandomAccess;
 use std::env::temp_dir;
 use std::fmt::Debug;
@@ -264,7 +264,7 @@ async fn audit() {
 async fn audit_bad_data() {
     let mut dir = temp_dir();
     dir.push("audit_bad_data");
-    let storage = Storage::new_disk(&dir, false).await.unwrap();
+    let storage = storage_disk(&dir, false).await.unwrap();
     let mut feed = Feed::with_storage(storage).await.unwrap();
     feed.append(b"hello").await.unwrap();
     feed.append(b"world").await.unwrap();

--- a/tests/feed.rs
+++ b/tests/feed.rs
@@ -3,17 +3,16 @@ extern crate random_access_memory as ram;
 mod common;
 
 use common::create_feed;
-use hypercore::{generate_keypair, storage_disk, Feed, NodeTrait, PublicKey, SecretKey, Storage};
-use random_access_storage::RandomAccess;
+use hypercore::{generate_keypair, Feed, NodeTrait, PublicKey, SecretKey, Storage};
+use hypercore::{storage_disk, storage_memory};
 use std::env::temp_dir;
-use std::fmt::Debug;
 use std::fs;
 use std::io::Write;
 
 #[async_std::test]
 async fn create_with_key() {
     let keypair = generate_keypair();
-    let storage = Storage::new_memory().await.unwrap();
+    let storage = storage_memory().await.unwrap();
     let _feed = Feed::builder(keypair.public, storage)
         .secret_key(keypair.secret)
         .build()
@@ -164,7 +163,7 @@ async fn put_with_data() {
 
     // Create a second feed with the first feed's key.
     let (public, secret) = copy_keys(&a);
-    let storage = Storage::new_memory().await.unwrap();
+    let storage = storage_memory().await.unwrap();
     let mut b = Feed::builder(public, storage)
         .secret_key(secret)
         .build()
@@ -197,7 +196,7 @@ async fn put_with_data() {
 
 #[async_std::test]
 async fn create_with_storage() {
-    let storage = Storage::new_memory().await.unwrap();
+    let storage = storage_memory().await.unwrap();
     assert!(
         Feed::with_storage(storage).await.is_ok(),
         "Could not create a feed with a storage."
@@ -206,7 +205,7 @@ async fn create_with_storage() {
 
 #[async_std::test]
 async fn create_with_stored_public_key() {
-    let mut storage = Storage::new_memory().await.unwrap();
+    let mut storage = storage_memory().await.unwrap();
     let keypair = generate_keypair();
     storage.write_public_key(&keypair.public).await.unwrap();
     assert!(
@@ -217,7 +216,7 @@ async fn create_with_stored_public_key() {
 
 #[async_std::test]
 async fn create_with_stored_keys() {
-    let mut storage = Storage::new_memory().await.unwrap();
+    let mut storage = storage_memory().await.unwrap();
     let keypair = generate_keypair();
     storage.write_public_key(&keypair.public).await.unwrap();
     storage.write_secret_key(&keypair.secret).await.unwrap();
@@ -227,9 +226,7 @@ async fn create_with_stored_keys() {
     );
 }
 
-fn copy_keys(
-    feed: &Feed<impl RandomAccess<Error = Box<dyn std::error::Error + Send + Sync>> + Debug + Send>,
-) -> (PublicKey, SecretKey) {
+fn copy_keys(feed: &Feed) -> (PublicKey, SecretKey) {
     match &feed.secret_key() {
         Some(secret) => {
             let secret = secret.to_bytes();
@@ -264,7 +261,7 @@ async fn audit() {
 async fn audit_bad_data() {
     let mut dir = temp_dir();
     dir.push("audit_bad_data");
-    let storage = storage_disk(&dir, false).await.unwrap();
+    let storage = storage_disk(&dir).await.unwrap();
     let mut feed = Feed::with_storage(storage).await.unwrap();
     feed.append(b"hello").await.unwrap();
     feed.append(b"world").await.unwrap();

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -1,5 +1,5 @@
 use ed25519_dalek::PublicKey;
-use hypercore::{generate_keypair, sign, verify, Signature, Storage};
+use hypercore::{generate_keypair, sign, storage_memory, verify, Signature};
 
 #[async_std::test]
 async fn should_write_and_read_keypair() {
@@ -8,7 +8,7 @@ async fn should_write_and_read_keypair() {
     // prepare a signature
     let sig: Signature = sign(&keypair.public, &keypair.secret, msg);
 
-    let mut storage = Storage::new_memory().await.unwrap();
+    let mut storage = storage_memory().await.unwrap();
     assert!(
         storage.write_secret_key(&keypair.secret).await.is_ok(),
         "Can not store secret key."
@@ -27,7 +27,7 @@ async fn should_write_and_read_keypair() {
 #[async_std::test]
 async fn should_read_partial_keypair() {
     let keypair = generate_keypair();
-    let mut storage = Storage::new_memory().await.unwrap();
+    let mut storage = storage_memory().await.unwrap();
     assert!(
         storage.write_public_key(&keypair.public).await.is_ok(),
         "Can not store public key."
@@ -39,13 +39,13 @@ async fn should_read_partial_keypair() {
 
 #[async_std::test]
 async fn should_read_no_keypair() {
-    let mut storage = Storage::new_memory().await.unwrap();
+    let mut storage = storage_memory().await.unwrap();
     let partial = storage.read_partial_keypair().await;
     assert!(partial.is_none(), "A key is present");
 }
 
 #[async_std::test]
 async fn should_read_empty_public_key() {
-    let mut storage = Storage::new_memory().await.unwrap();
+    let mut storage = storage_memory().await.unwrap();
     assert!(storage.read_public_key().await.is_err());
 }


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:**  a 🙋 feature

This PR adds a `subscribe` method to the Feed which returns a `Receiver<Event>`. Currently, there's two events being emitted: `Download` and `Append`. More can be added over time/when needed.

I think this will be important for upcoming replication integration.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
<!-- Is this related to any GitHub issue(s)? -->

## Semver Changes
<!-- Which semantic version change would you recommend? -->
minor as it's only an API addition I think