### PR TITLE
Emit events to be used for replication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ test-log = { version = "0.2.11", default-features = false, features = ["trace"] 
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
 
 [features]
-default = ["async-std", "sparse"]
+default = ["tokio", "sparse"]
 sparse = ["random-access-disk/sparse"]
 tokio = ["dep:tokio", "random-access-disk/tokio"]
 async-std = ["random-access-disk/async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ futures = "0.3"
 crc32fast = "1"
 intmap = "2"
 moka = { version = "0.12", optional = true, features = ["sync"] }
-tokio = { version = "1.27.0", features = ["sync"] }
+tokio = { version = "1.27.0", features = ["sync"], optional = true}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 random-access-disk = { version = "3", default-features = false }
@@ -62,7 +62,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
 [features]
 default = ["async-std", "sparse"]
 sparse = ["random-access-disk/sparse"]
-tokio = ["random-access-disk/tokio"]
+tokio = ["dep:tokio", "random-access-disk/tokio"]
 async-std = ["random-access-disk/async-std"]
 cache = ["moka"]
 # Used only in interoperability tests under tests/js-interop which use the javascript version of hypercore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ futures = "0.3"
 crc32fast = "1"
 intmap = "2"
 moka = { version = "0.12", optional = true, features = ["sync"] }
+tokio = { version = "1.27.0", features = ["sync"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 random-access-disk = { version = "3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ futures = "0.3"
 crc32fast = "1"
 intmap = "2"
 moka = { version = "0.12", optional = true, features = ["sync"] }
-tokio = { version = "1.27.0", features = ["sync"], optional = true}
+tokio = { version = "1.27.0", features = ["rt", "sync"], optional = true}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 random-access-disk = { version = "3", default-features = false }

--- a/src/common/node.rs
+++ b/src/common/node.rs
@@ -20,10 +20,15 @@ pub(crate) struct NodeByteRange {
 // disk.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Node {
+    /// TODO document me
     pub(crate) index: u64,
+    /// hash of the data in this node
     pub(crate) hash: Vec<u8>,
+    /// number of bytes of the data
     pub(crate) length: u64,
     pub(crate) parent: u64,
+    /// The data. Other metadata in this struct is provided before the actual data.
+    /// so it is optional
     pub(crate) data: Option<Vec<u8>>,
     pub(crate) blank: bool,
 }

--- a/src/common/peer.rs
+++ b/src/common/peer.rs
@@ -1,6 +1,8 @@
 //! Types needed for passing information with with peers.
 //! hypercore-protocol-rs uses these types and wraps them
 //! into wire messages.
+use std::fmt::Display;
+
 use crate::Node;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -114,4 +116,17 @@ pub struct DataUpgrade {
     pub additional_nodes: Vec<Node>,
     /// TODO: Document
     pub signature: Vec<u8>,
+}
+
+impl Display for DataUpgrade {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DataUpgrade(start: {}, length: {}, nodes: {:?}, .., signature: {})",
+            self.start,
+            self.length,
+            self.nodes,
+            self.signature.len()
+        )
+    }
 }

--- a/src/common/peer.rs
+++ b/src/common/peer.rs
@@ -104,11 +104,11 @@ pub struct DataSeek {
 #[derive(Debug, Clone, PartialEq)]
 /// TODO: Document
 pub struct DataUpgrade {
-    /// TODO: Document
+    /// starting block of this upgrade response
     pub start: u64,
-    /// TODO: Document
+    /// number of blocks in this upgrade response
     pub length: u64,
-    /// TODO: Document
+    /// the metadata nodes?
     pub nodes: Vec<Node>,
     /// TODO: Document
     pub additional_nodes: Vec<Node>,

--- a/src/core.rs
+++ b/src/core.rs
@@ -44,7 +44,11 @@ impl HypercoreOptions {
 #[cfg(feature = "tokio")]
 #[derive(Debug)]
 struct Events {
+    /// Sends a notification to the replicator that core is upgraded
     on_upgrade: Sender<()>,
+    /// Notify receiver to get block over the network.
+    /// maybe should not return the block itself
+    on_get: Sender<(u64, Sender<()>)>,
 }
 
 #[cfg(feature = "tokio")]

--- a/src/core.rs
+++ b/src/core.rs
@@ -340,14 +340,9 @@ impl Hypercore {
             }
         }
 
-        // if we drop the receiver and there are no listeners, this will error, but we don't care
-        match self.events.onupgrade.send(()) {
-            Err(e) => {
-                dbg!(e);
-                ()
-            }
-            Ok(_) => (),
-        }
+        // NB: send() returns an error when there are no receivers. Which is the case when there is
+        // no replication. We ignore the error. No recievers is ok.
+        let _ = self.events.onupgrade.send(());
 
         // Return the new value
         Ok(AppendOutcome {

--- a/src/core.rs
+++ b/src/core.rs
@@ -43,15 +43,14 @@ impl HypercoreOptions {
 #[cfg(feature = "tokio")]
 #[derive(Debug)]
 struct Events {
-    onupgrade: Sender<()>,
+    on_upgrade: Sender<()>,
 }
 
 #[cfg(feature = "tokio")]
 impl Events {
     fn new() -> Self {
-        Self {
-            onupgrade: broadcast::channel(MAX_EVENT_QUEUE_CAPACITY).0,
-        }
+        let (sender, _) = broadcast::channel(MAX_EVENT_QUEUE_CAPACITY);
+        Self { on_upgrade: sender }
     }
 }
 
@@ -348,7 +347,7 @@ impl Hypercore {
         // NB: send() returns an error when there are no receivers. Which is the case when there is
         // no replication. We ignore the error. No recievers is ok.
         #[cfg(feature = "tokio")]
-        let _ = self.events.onupgrade.send(());
+        let _ = self.events.on_upgrade.send(());
 
         // Return the new value
         Ok(AppendOutcome {
@@ -359,8 +358,8 @@ impl Hypercore {
 
     #[cfg(feature = "tokio")]
     /// Subscribe to upgrade events
-    pub fn onupgrade(&self) -> Receiver<()> {
-        self.events.onupgrade.subscribe()
+    pub fn on_upgrade(&self) -> Receiver<()> {
+        self.events.on_upgrade.subscribe()
     }
 
     /// Read value at given index, if any.

--- a/src/core.rs
+++ b/src/core.rs
@@ -7,6 +7,7 @@ use std::fmt::Debug;
 use tokio::sync::broadcast::{self, Receiver, Sender};
 use tracing::instrument;
 
+#[cfg(feature = "tokio")]
 static MAX_EVENT_QUEUE_CAPACITY: usize = 32;
 #[cfg(feature = "cache")]
 use crate::common::cache::CacheOptions;

--- a/src/core.rs
+++ b/src/core.rs
@@ -392,7 +392,7 @@ impl Hypercore {
                 let mut rx = self.on_get(index);
                 //let res = rx.recv().await.unwrap();
                 tokio::spawn(async move {
-                    rx.recv().await;
+                    let _ = rx.recv().await;
                 });
             }
             return Ok(None);

--- a/src/core.rs
+++ b/src/core.rs
@@ -3,6 +3,7 @@ use ed25519_dalek::Signature;
 use futures::future::Either;
 use std::convert::TryFrom;
 use std::fmt::Debug;
+#[cfg(feature = "tokio")]
 use tokio::sync::broadcast::{self, Receiver, Sender};
 use tracing::instrument;
 
@@ -39,11 +40,13 @@ impl HypercoreOptions {
     }
 }
 
+#[cfg(feature = "tokio")]
 #[derive(Debug)]
 struct Events {
     onupgrade: Sender<()>,
 }
 
+#[cfg(feature = "tokio")]
 impl Events {
     fn new() -> Self {
         Self {
@@ -63,6 +66,7 @@ pub struct Hypercore {
     pub(crate) bitfield: Bitfield,
     skip_flush_count: u8, // autoFlush in Javascript
     header: Header,
+    #[cfg(feature = "tokio")]
     events: Events,
 }
 
@@ -263,6 +267,7 @@ impl Hypercore {
             bitfield,
             header,
             skip_flush_count: 0,
+            #[cfg(feature = "tokio")]
             events: Events::new(),
         })
     }
@@ -342,6 +347,7 @@ impl Hypercore {
 
         // NB: send() returns an error when there are no receivers. Which is the case when there is
         // no replication. We ignore the error. No recievers is ok.
+        #[cfg(feature = "tokio")]
         let _ = self.events.onupgrade.send(());
 
         // Return the new value
@@ -351,6 +357,7 @@ impl Hypercore {
         })
     }
 
+    #[cfg(feature = "tokio")]
     /// Subscribe to upgrade events
     pub fn onupgrade(&self) -> Receiver<()> {
         self.events.onupgrade.subscribe()


### PR DESCRIPTION

this  a 🙋 feature

This pull request provides a way for the Hypercore to emit events which are intended to be used with replication. 
The target implementation of replication [here](https://github.com/cowlicks/replicator). But this should be general enough to use with other implementations.

This is a work-in-progress and is currently provided just for visibility. 

## Context

Replicator repository is [here](https://github.com/cowlicks/replicator)

This would partially supersede this other PR #116 (which cannot merge due to conflict)

## Semver Changes
hopefully minor