### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,12 @@ jobs:
         components: rustfmt
     - name: Run tests
       run: |
-        cargo check --no-default-features --features tokio
-        cargo check --no-default-features --features tokio,sparse
-        cargo check --no-default-features --features tokio,sparse,cache
-        cargo check --no-default-features --features async-std
-        cargo check --no-default-features --features async-std,sparse
-        cargo check --no-default-features --features async-std,sparse,cache
+        cargo check --all-targets --no-default-features --features tokio
+        cargo check --all-targets --no-default-features --features tokio,sparse
+        cargo check --all-targets --no-default-features --features tokio,sparse,cache
+        cargo check --all-targets --no-default-features --features async-std
+        cargo check --all-targets --no-default-features --features async-std,sparse
+        cargo check --all-targets --no-default-features --features async-std,sparse,cache
         cargo test --no-default-features --features js_interop_tests,tokio
         cargo test --no-default-features --features js_interop_tests,tokio,sparse
         cargo test --no-default-features --features js_interop_tests,tokio,sparse,cache
@@ -57,12 +57,12 @@ jobs:
           components: rustfmt
       - name: Run tests
         run: |
-          cargo check --no-default-features --features tokio
-          cargo check --no-default-features --features tokio,sparse
-          cargo check --no-default-features --features tokio,sparse,cache
-          cargo check --no-default-features --features async-std
-          cargo check --no-default-features --features async-std,sparse
-          cargo check --no-default-features --features async-std,sparse,cache
+          cargo check --all-targets --no-default-features --features tokio
+          cargo check --all-targets --no-default-features --features tokio,sparse
+          cargo check --all-targets --no-default-features --features tokio,sparse,cache
+          cargo check --all-targets --no-default-features --features async-std
+          cargo check --all-targets --no-default-features --features async-std,sparse
+          cargo check --all-targets --no-default-features --features async-std,sparse,cache
           cargo test --no-default-features --features tokio
           cargo test --no-default-features --features tokio,sparse
           cargo test --no-default-features --features tokio,sparse,cache
@@ -82,12 +82,12 @@ jobs:
           components: rustfmt
       - name: Run tests
         run: |
-          cargo check --no-default-features --features tokio
-          cargo check --no-default-features --features tokio,sparse
-          cargo check --no-default-features --features tokio,sparse,cache
-          cargo check --no-default-features --features async-std
-          cargo check --no-default-features --features async-std,sparse
-          cargo check --no-default-features --features async-std,sparse,cache
+          cargo check --all-targets --no-default-features --features tokio
+          cargo check --all-targets --no-default-features --features tokio,sparse
+          cargo check --all-targets --no-default-features --features tokio,sparse,cache
+          cargo check --all-targets --no-default-features --features async-std
+          cargo check --all-targets --no-default-features --features async-std,sparse
+          cargo check --all-targets --no-default-features --features async-std,sparse,cache
           cargo test --no-default-features --features js_interop_tests,tokio
           cargo test --no-default-features --features js_interop_tests,tokio,sparse
           cargo test --no-default-features --features js_interop_tests,tokio,sparse,cache

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -25,7 +25,7 @@ async fn create_hypercore(page_size: usize) -> Result<Hypercore, HypercoreError>
     let storage = Storage::open(
         |_| {
             Box::pin(async move {
-                Ok(Box::new(RandomAccessMemory::new(page_size)) as Box<dyn StorageTraits>)
+                Ok(Box::new(RandomAccessMemory::new(page_size)) as Box<dyn StorageTraits + Send>)
             })
         },
         false,
@@ -44,7 +44,7 @@ async fn create_hypercore(page_size: usize) -> Result<Hypercore, HypercoreError>
     let storage = Storage::open(
         |_| {
             Box::pin(async move {
-                Ok(Box::new(RandomAccessMemory::new(page_size)) as Box<dyn StorageTraits>)
+                Ok(Box::new(RandomAccessMemory::new(page_size)) as Box<dyn StorageTraits + Send>)
             })
         },
         false,

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -5,6 +5,6 @@
         "step": "node interop.js"
     },
     "dependencies": {
-        "hypercore": "^10"
+        "hypercore": "10.31.12"
     }
 }


### PR DESCRIPTION
* Pin the last compatible version of JS hypercore to 10.31.12 for `js_interop_tests`
* Fix errors in the benches that were hidden by the broken `js_interop_tests`
* Add `--all-targets` arguments to the CI `cargo check` commands. This catches problems in benches, tests, and examples.