### PR TITLE
Update to new version of compact encodable and use it Clean up encoding implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+  RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
   ci-pass:
@@ -145,4 +147,6 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Format check
       run: |
+        cargo doc
         cargo fmt -- --check
+        cargo clippy --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 getrandom = { version = "0.2", features = ["js"] }
 thiserror = "1"
 tracing = "0.1"
-compact-encoding = "1"
+#compact-encoding = "1"
 flat-tree = "6"
 merkle-tree-stream =  "0.12"
 pretty-hash = "0.4"
@@ -44,6 +44,9 @@ async-lock = {version = "3.4.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 random-access-disk = { version = "3", default-features = false }
+
+[dependencies.compact-encoding]
+path = "../compact-encoding"
 
 [dev-dependencies]
 anyhow = "1.0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ed25519-dalek = { version = "2", features = ["rand_core"] }
 getrandom = { version = "0.2", features = ["js"] }
 thiserror = "1"
 tracing = "0.1"
-#compact-encoding = "1"
+compact-encoding = "2"
 flat-tree = "6"
 merkle-tree-stream =  "0.12"
 pretty-hash = "0.4"
@@ -44,9 +44,6 @@ async-lock = {version = "3.4.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 random-access-disk = { version = "3", default-features = false }
-
-[dependencies.compact-encoding]
-path = "../compact-encoding"
 
 [dev-dependencies]
 anyhow = "1.0.70"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ random-access-disk = { version = "3", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.70"
-proptest = "1.1.0"
-proptest-derive = "0.2.0"
+proptest = "1.6.0"
+proptest-derive = "0.5.1"
 data-encoding = "2.2.0"
 remove_dir_all = "0.7.0"
 tempfile = "3.1.0"

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,7 +16,7 @@ pub use self::store::Store;
 pub(crate) use self::store::{StoreInfo, StoreInfoInstruction, StoreInfoType};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BitfieldUpdate {
+pub(crate) struct BitfieldUpdate {
     pub(crate) drop: bool,
     pub(crate) start: u64,
     pub(crate) length: u64,

--- a/src/common/node.rs
+++ b/src/common/node.rs
@@ -23,6 +23,8 @@ pub struct Node {
     /// This node's index in the Merkle tree
     pub(crate) index: u64,
     /// Hash of the data in this node
+    // TODO make this [u8; 32] like:
+    // https://github.com/holepunchto/hypercore/blob/d21ebdeca1b27eb4c2232f8af17d5ae939ee97f2/lib/messages.js#L246
     pub(crate) hash: Vec<u8>,
     /// Number of bytes in this [`Node::data`]
     pub(crate) length: u64,

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -168,8 +168,13 @@ impl Hash {
 
         for node in roots {
             let node = node.as_ref();
-            let buffer = (|| Ok::<_, EncodingError>(to_encoded_bytes!(node.index(), node.len())))()
-                .expect("Encoding u64 should not fail");
+            let buffer = (|| {
+                Ok::<_, EncodingError>(to_encoded_bytes!(
+                    node.index().as_fixed_width(),
+                    node.len().as_fixed_width()
+                ))
+            })()
+            .expect("Encoding u64 should not fail");
 
             hasher.update(node.hash());
             hasher.update(&buffer[..8]);

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -3,9 +3,7 @@ use blake2::{
     Blake2b, Blake2bMac, Digest,
 };
 use byteorder::{BigEndian, WriteBytesExt};
-use compact_encoding::{
-    as_array, to_encoded_bytes, CompactEncoding, EncodingError, FixedWidthEncoding,
-};
+use compact_encoding::{as_array, to_encoded_bytes, EncodingError, FixedWidthEncoding};
 use ed25519_dalek::VerifyingKey;
 use merkle_tree_stream::Node as NodeTrait;
 use std::convert::AsRef;

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -147,8 +147,9 @@ impl Hash {
         };
 
         let len = node1.length + node2.length;
-        let size: Vec<u8> = (|| Ok::<_, EncodingError>(to_encoded_bytes!(len.as_fixed_width())))()
-            .expect("Encoding u64 should not fail");
+        let size: Box<[u8]> =
+            (|| Ok::<_, EncodingError>(to_encoded_bytes!(len.as_fixed_width())))()
+                .expect("Encoding u64 should not fail");
 
         let mut hasher = Blake2b256::new();
         hasher.update(PARENT_TYPE);

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -220,7 +220,6 @@ pub(crate) fn signable_tree(hash: &[u8], length: u64, fork: u64) -> Box<[u8]> {
         ))
     })()
     .expect("Encoding should not fail")
-    .into()
 }
 
 #[cfg(test)]

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -22,10 +22,7 @@ impl CompactEncoding for Node {
     where
         Self: Sized,
     {
-        let (index, rest) = u64::decode(buffer)?;
-        let (length, rest) = u64::decode(rest)?;
-        let (hash, rest) = <[u8; 32]>::decode(rest)?;
-
+        let ((index, length, hash), rest) = map_decode!(buffer, [u64, u64, [u8; 32]]);
         Ok((Node::new(index, hash.to_vec(), length), rest))
     }
 }
@@ -56,8 +53,7 @@ impl CompactEncoding for RequestBlock {
     where
         Self: Sized,
     {
-        let (index, rest) = u64::decode(buffer)?;
-        let (nodes, rest) = u64::decode(rest)?;
+        let ((index, nodes), rest) = map_decode!(buffer, [u64, u64]);
         Ok((RequestBlock { index, nodes }, rest))
     }
 }
@@ -93,8 +89,7 @@ impl CompactEncoding for RequestUpgrade {
     where
         Self: Sized,
     {
-        let (start, rest) = u64::decode(buffer)?;
-        let (length, rest) = u64::decode(rest)?;
+        let ((start, length), rest) = map_decode!(buffer, [u64, u64]);
         Ok((RequestUpgrade { start, length }, rest))
     }
 }
@@ -112,9 +107,7 @@ impl CompactEncoding for DataBlock {
     where
         Self: Sized,
     {
-        let (index, rest) = u64::decode(buffer)?;
-        let (value, rest) = Vec::<u8>::decode(rest)?;
-        let (nodes, rest) = Vec::<Node>::decode(rest)?;
+        let ((index, value, nodes), rest) = map_decode!(buffer, [u64, Vec<u8>, Vec<Node>]);
         Ok((
             DataBlock {
                 index,
@@ -139,8 +132,7 @@ impl CompactEncoding for DataHash {
     where
         Self: Sized,
     {
-        let (index, rest) = u64::decode(buffer)?;
-        let (nodes, rest) = Vec::<Node>::decode(rest)?;
+        let ((index, nodes), rest) = map_decode!(buffer, [u64, Vec<Node>]);
         Ok((DataHash { index, nodes }, rest))
     }
 }
@@ -158,8 +150,7 @@ impl CompactEncoding for DataSeek {
     where
         Self: Sized,
     {
-        let (bytes, rest) = u64::decode(buffer)?;
-        let (nodes, rest) = Vec::<Node>::decode(rest)?;
+        let ((bytes, nodes), rest) = map_decode!(buffer, [u64, Vec<Node>]);
         Ok((DataSeek { bytes, nodes }, rest))
     }
 }
@@ -192,11 +183,8 @@ impl CompactEncoding for DataUpgrade {
     where
         Self: Sized,
     {
-        let (start, rest) = u64::decode(buffer)?;
-        let (length, rest) = u64::decode(rest)?;
-        let (nodes, rest) = Vec::<Node>::decode(rest)?;
-        let (additional_nodes, rest) = Vec::<Node>::decode(rest)?;
-        let (signature, rest) = <Vec<u8>>::decode(rest)?;
+        let ((start, length, nodes, additional_nodes, signature), rest) =
+            map_decode!(buffer, [u64, u64, Vec<Node>, Vec<Node>, Vec<u8>]);
         Ok((
             DataUpgrade {
                 start,

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,382 +1,16 @@
 //! Hypercore-specific compact encodings
-pub use compact_encoding::{
-    encodable::{
-        bytes_fixed_from_vec, encode_bytes_fixed, take_array, take_array_mut, usize_encoded_size,
-        write_array, write_slice, CompactEncodable, VecEncodable,
-    },
-    CompactEncoding, EncodingError, EncodingErrorKind, State,
-};
-use std::convert::TryInto;
-use std::ops::{Deref, DerefMut};
-
 use crate::{
     crypto::{Manifest, ManifestSigner},
     DataBlock, DataHash, DataSeek, DataUpgrade, Node, RequestBlock, RequestSeek, RequestUpgrade,
 };
-
-#[derive(Debug, Clone)]
-/// Wrapper struct for compact_encoding::State
-pub struct HypercoreState(pub State);
-
-impl Default for HypercoreState {
-    /// Passthrought to compact_encoding
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl HypercoreState {
-    /// Passthrought to compact_encoding
-    pub fn new() -> HypercoreState {
-        HypercoreState(State::new())
-    }
-
-    /// Passthrought to compact_encoding
-    pub fn new_with_size(size: usize) -> (HypercoreState, Box<[u8]>) {
-        let (state, buffer) = State::new_with_size(size);
-        (HypercoreState(state), buffer)
-    }
-
-    /// Passthrought to compact_encoding
-    pub fn new_with_start_and_end(start: usize, end: usize) -> HypercoreState {
-        HypercoreState(State::new_with_start_and_end(start, end))
-    }
-
-    /// Passthrought to compact_encoding
-    pub fn from_buffer(buffer: &[u8]) -> HypercoreState {
-        HypercoreState(State::from_buffer(buffer))
-    }
-}
-
-impl Deref for HypercoreState {
-    type Target = State;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for HypercoreState {
-    fn deref_mut(&mut self) -> &mut State {
-        &mut self.0
-    }
-}
-
-impl CompactEncoding<Node> for HypercoreState {
-    fn preencode(&mut self, value: &Node) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.index)?;
-        self.0.preencode(&value.length)?;
-        self.0.preencode_fixed_32()
-    }
-
-    fn encode(&mut self, value: &Node, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.0.encode(&value.index, buffer)?;
-        self.0.encode(&value.length, buffer)?;
-        self.0.encode_fixed_32(&value.hash, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<Node, EncodingError> {
-        let index: u64 = self.0.decode(buffer)?;
-        let length: u64 = self.0.decode(buffer)?;
-        let hash: Box<[u8]> = self.0.decode_fixed_32(buffer)?;
-        Ok(Node::new(index, hash.to_vec(), length))
-    }
-}
-
-impl CompactEncoding<Vec<Node>> for HypercoreState {
-    fn preencode(&mut self, value: &Vec<Node>) -> Result<usize, EncodingError> {
-        let len = value.len();
-        self.0.preencode(&len)?;
-        for val in value {
-            self.preencode(val)?;
-        }
-        Ok(self.end())
-    }
-
-    fn encode(&mut self, value: &Vec<Node>, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        let len = value.len();
-        self.0.encode(&len, buffer)?;
-        for val in value {
-            self.encode(val, buffer)?;
-        }
-        Ok(self.start())
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<Vec<Node>, EncodingError> {
-        let len: usize = self.0.decode(buffer)?;
-        let mut value = Vec::with_capacity(len);
-        for _ in 0..len {
-            value.push(self.decode(buffer)?);
-        }
-        Ok(value)
-    }
-}
-
-impl CompactEncoding<RequestBlock> for HypercoreState {
-    fn preencode(&mut self, value: &RequestBlock) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.index)?;
-        self.0.preencode(&value.nodes)
-    }
-
-    fn encode(&mut self, value: &RequestBlock, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.0.encode(&value.index, buffer)?;
-        self.0.encode(&value.nodes, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<RequestBlock, EncodingError> {
-        let index: u64 = self.0.decode(buffer)?;
-        let nodes: u64 = self.0.decode(buffer)?;
-        Ok(RequestBlock { index, nodes })
-    }
-}
-
-impl CompactEncoding<RequestSeek> for HypercoreState {
-    fn preencode(&mut self, value: &RequestSeek) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.bytes)
-    }
-
-    fn encode(&mut self, value: &RequestSeek, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.0.encode(&value.bytes, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<RequestSeek, EncodingError> {
-        let bytes: u64 = self.0.decode(buffer)?;
-        Ok(RequestSeek { bytes })
-    }
-}
-
-impl CompactEncoding<RequestUpgrade> for HypercoreState {
-    fn preencode(&mut self, value: &RequestUpgrade) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.start)?;
-        self.0.preencode(&value.length)
-    }
-
-    fn encode(
-        &mut self,
-        value: &RequestUpgrade,
-        buffer: &mut [u8],
-    ) -> Result<usize, EncodingError> {
-        self.0.encode(&value.start, buffer)?;
-        self.0.encode(&value.length, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<RequestUpgrade, EncodingError> {
-        let start: u64 = self.0.decode(buffer)?;
-        let length: u64 = self.0.decode(buffer)?;
-        Ok(RequestUpgrade { start, length })
-    }
-}
-
-impl CompactEncoding<DataBlock> for HypercoreState {
-    fn preencode(&mut self, value: &DataBlock) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.index)?;
-        self.0.preencode(&value.value)?;
-        self.preencode(&value.nodes)
-    }
-
-    fn encode(&mut self, value: &DataBlock, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.0.encode(&value.index, buffer)?;
-        self.0.encode(&value.value, buffer)?;
-        self.encode(&value.nodes, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<DataBlock, EncodingError> {
-        let index: u64 = self.0.decode(buffer)?;
-        let value: Vec<u8> = self.0.decode(buffer)?;
-        let nodes: Vec<Node> = self.decode(buffer)?;
-        Ok(DataBlock {
-            index,
-            value,
-            nodes,
-        })
-    }
-}
-
-impl CompactEncoding<DataHash> for HypercoreState {
-    fn preencode(&mut self, value: &DataHash) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.index)?;
-        self.preencode(&value.nodes)
-    }
-
-    fn encode(&mut self, value: &DataHash, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.0.encode(&value.index, buffer)?;
-        self.encode(&value.nodes, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<DataHash, EncodingError> {
-        let index: u64 = self.0.decode(buffer)?;
-        let nodes: Vec<Node> = self.decode(buffer)?;
-        Ok(DataHash { index, nodes })
-    }
-}
-
-impl CompactEncoding<DataSeek> for HypercoreState {
-    fn preencode(&mut self, value: &DataSeek) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.bytes)?;
-        self.preencode(&value.nodes)
-    }
-
-    fn encode(&mut self, value: &DataSeek, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.0.encode(&value.bytes, buffer)?;
-        self.encode(&value.nodes, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<DataSeek, EncodingError> {
-        let bytes: u64 = self.0.decode(buffer)?;
-        let nodes: Vec<Node> = self.decode(buffer)?;
-        Ok(DataSeek { bytes, nodes })
-    }
-}
-
-impl CompactEncoding<DataUpgrade> for HypercoreState {
-    fn preencode(&mut self, value: &DataUpgrade) -> Result<usize, EncodingError> {
-        self.0.preencode(&value.start)?;
-        self.0.preencode(&value.length)?;
-        self.preencode(&value.nodes)?;
-        self.preencode(&value.additional_nodes)?;
-        self.0.preencode(&value.signature)
-    }
-
-    fn encode(&mut self, value: &DataUpgrade, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.0.encode(&value.start, buffer)?;
-        self.0.encode(&value.length, buffer)?;
-        self.encode(&value.nodes, buffer)?;
-        self.encode(&value.additional_nodes, buffer)?;
-        self.0.encode(&value.signature, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<DataUpgrade, EncodingError> {
-        let start: u64 = self.0.decode(buffer)?;
-        let length: u64 = self.0.decode(buffer)?;
-        let nodes: Vec<Node> = self.decode(buffer)?;
-        let additional_nodes: Vec<Node> = self.decode(buffer)?;
-        let signature: Vec<u8> = self.0.decode(buffer)?;
-        Ok(DataUpgrade {
-            start,
-            length,
-            nodes,
-            additional_nodes,
-            signature,
-        })
-    }
-}
-
-impl CompactEncoding<Manifest> for State {
-    fn preencode(&mut self, value: &Manifest) -> Result<usize, EncodingError> {
-        self.add_end(1)?; // Version
-        self.add_end(1)?; // hash in one byte
-        self.add_end(1)?; // type in one byte
-        self.preencode(&value.signer)
-    }
-
-    fn encode(&mut self, value: &Manifest, buffer: &mut [u8]) -> Result<usize, EncodingError> {
-        self.set_byte_to_buffer(0, buffer)?; // Version
-        if &value.hash == "blake2b" {
-            self.set_byte_to_buffer(0, buffer)?; // Version
-        } else {
-            return Err(EncodingError::new(
-                EncodingErrorKind::InvalidData,
-                &format!("Unknown hash: {}", &value.hash),
-            ));
-        }
-        // Type. 0: static, 1: signer, 2: multiple signers
-        self.set_byte_to_buffer(1, buffer)?; // Version
-        self.encode(&value.signer, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<Manifest, EncodingError> {
-        let version: u8 = self.decode_u8(buffer)?;
-        if version != 0 {
-            panic!("Unknown manifest version {}", version);
-        }
-        let hash_id: u8 = self.decode_u8(buffer)?;
-        let hash: String = if hash_id != 0 {
-            return Err(EncodingError::new(
-                EncodingErrorKind::InvalidData,
-                &format!("Unknown hash id: {hash_id}"),
-            ));
-        } else {
-            "blake2b".to_string()
-        };
-
-        let manifest_type: u8 = self.decode_u8(buffer)?;
-        if manifest_type != 1 {
-            return Err(EncodingError::new(
-                EncodingErrorKind::InvalidData,
-                &format!("Unknown manifest type: {manifest_type}"),
-            ));
-        }
-        let signer: ManifestSigner = self.decode(buffer)?;
-
-        Ok(Manifest { hash, signer })
-    }
-}
-
-impl CompactEncoding<ManifestSigner> for State {
-    fn preencode(&mut self, _value: &ManifestSigner) -> Result<usize, EncodingError> {
-        self.add_end(1)?; // Signature
-        self.preencode_fixed_32()?;
-        self.preencode_fixed_32()
-    }
-
-    fn encode(
-        &mut self,
-        value: &ManifestSigner,
-        buffer: &mut [u8],
-    ) -> Result<usize, EncodingError> {
-        if &value.signature == "ed25519" {
-            self.set_byte_to_buffer(0, buffer)?;
-        } else {
-            return Err(EncodingError::new(
-                EncodingErrorKind::InvalidData,
-                &format!("Unknown signature type: {}", &value.signature),
-            ));
-        }
-        self.encode_fixed_32(&value.namespace, buffer)?;
-        self.encode_fixed_32(&value.public_key, buffer)
-    }
-
-    fn decode(&mut self, buffer: &[u8]) -> Result<ManifestSigner, EncodingError> {
-        let signature_id: u8 = self.decode_u8(buffer)?;
-        let signature: String = if signature_id != 0 {
-            return Err(EncodingError::new(
-                EncodingErrorKind::InvalidData,
-                &format!("Unknown signature id: {signature_id}"),
-            ));
-        } else {
-            "ed25519".to_string()
-        };
-        let namespace: [u8; 32] =
-            self.decode_fixed_32(buffer)?
-                .to_vec()
-                .try_into()
-                .map_err(|_err| {
-                    EncodingError::new(
-                        EncodingErrorKind::InvalidData,
-                        "Invalid namespace in manifest signer",
-                    )
-                })?;
-        let public_key: [u8; 32] =
-            self.decode_fixed_32(buffer)?
-                .to_vec()
-                .try_into()
-                .map_err(|_err| {
-                    EncodingError::new(
-                        EncodingErrorKind::InvalidData,
-                        "Invalid public key in manifest signer",
-                    )
-                })?;
-
-        Ok(ManifestSigner {
-            signature,
-            namespace,
-            public_key,
-        })
-    }
-}
+use compact_encoding::encoded_size_usize;
+pub use compact_encoding::{
+    bytes_fixed_from_vec, encode_bytes_fixed, take_array, take_array_mut, write_array, write_slice,
+    CompactEncoding, EncodingError, EncodingErrorKind, VecEncodable,
+};
 
 #[macro_export]
-/// Used for defining CompactEncodable::encoded_size.
+/// Used for defining CompactEncoding::encoded_size.
 /// Pass self and a list of fields to call encoded_size on
 macro_rules! sum_encoded_size {
     // Base case: single field
@@ -391,7 +25,7 @@ macro_rules! sum_encoded_size {
 
 #[macro_export]
 // TODO is this exported from the crate?
-/// Used for defining CompactEncodable::encode.
+/// Used for defining CompactEncoding::encode.
 /// Pass self, the buffer and a list of fields to call encoded_size on
 macro_rules! chain_encoded_bytes {
     // Base case: single field
@@ -405,7 +39,7 @@ macro_rules! chain_encoded_bytes {
     }};
 }
 
-impl CompactEncodable for Node {
+impl CompactEncoding for Node {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(self, index, length) + 32)
     }
@@ -431,7 +65,7 @@ impl VecEncodable for Node {
     where
         Self: Sized,
     {
-        let mut out = usize_encoded_size(vec.len());
+        let mut out = encoded_size_usize(vec.len());
         for x in vec {
             out += x.encoded_size()?;
         }
@@ -439,7 +73,7 @@ impl VecEncodable for Node {
     }
 }
 
-impl CompactEncodable for RequestBlock {
+impl CompactEncoding for RequestBlock {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(self, index, nodes))
     }
@@ -458,7 +92,7 @@ impl CompactEncodable for RequestBlock {
     }
 }
 
-impl CompactEncodable for RequestSeek {
+impl CompactEncoding for RequestSeek {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         self.bytes.encoded_size()
     }
@@ -476,7 +110,7 @@ impl CompactEncodable for RequestSeek {
     }
 }
 
-impl CompactEncodable for RequestUpgrade {
+impl CompactEncoding for RequestUpgrade {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(self, start, length))
     }
@@ -495,7 +129,7 @@ impl CompactEncodable for RequestUpgrade {
     }
 }
 
-impl CompactEncodable for DataBlock {
+impl CompactEncoding for DataBlock {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(self, index, value, nodes))
     }
@@ -522,7 +156,7 @@ impl CompactEncodable for DataBlock {
     }
 }
 
-impl CompactEncodable for DataHash {
+impl CompactEncoding for DataHash {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(self, index, nodes))
     }
@@ -541,7 +175,7 @@ impl CompactEncodable for DataHash {
     }
 }
 
-impl CompactEncodable for DataSeek {
+impl CompactEncoding for DataSeek {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(self, bytes, nodes))
     }
@@ -560,7 +194,7 @@ impl CompactEncodable for DataSeek {
     }
 }
 
-impl CompactEncodable for DataUpgrade {
+impl CompactEncoding for DataUpgrade {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(
             self,
@@ -606,7 +240,7 @@ impl CompactEncodable for DataUpgrade {
     }
 }
 
-impl CompactEncodable for ManifestSigner {
+impl CompactEncoding for ManifestSigner {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(
             1  /* Signature */ + 32  /* namespace */ + 32, /* public_key */
@@ -653,7 +287,7 @@ impl CompactEncodable for ManifestSigner {
     }
 }
 
-impl CompactEncodable for Manifest {
+impl CompactEncoding for Manifest {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(1 // Version
         + 1 // hash in one byte
@@ -701,24 +335,5 @@ impl CompactEncodable for Manifest {
         }
         let (signer, rest) = ManifestSigner::decode(rest)?;
         Ok((Manifest { hash, signer }, rest))
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn cmp_node_enc() -> Result<(), EncodingError> {
-        let node = Node::new(1, vec![4; 32], 66);
-        let my_buf = CompactEncodable::to_bytes(&node)?;
-        let mut state = HypercoreState::new();
-
-        state.preencode(&node)?;
-        assert_eq!(my_buf.len(), state.end());
-        let mut buf = vec![0; state.end()];
-        state.encode(&node, &mut buf)?;
-        assert_eq!(my_buf, buf);
-        Ok(())
     }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -3,11 +3,9 @@ use crate::{
     crypto::{Manifest, ManifestSigner},
     DataBlock, DataHash, DataSeek, DataUpgrade, Node, RequestBlock, RequestSeek, RequestUpgrade,
 };
-use compact_encoding::{as_array, encoded_size_usize};
-pub use compact_encoding::{
-    bytes_fixed_from_vec, decode_usize, encode_bytes_fixed, map_decode, map_encode,
-    sum_encoded_size, take_array, take_array_mut, to_encoded_bytes, write_array, write_slice,
-    CompactEncoding, EncodingError, EncodingErrorKind, VecEncodable,
+use compact_encoding::{
+    as_array, encode_bytes_fixed, encoded_size_usize, map_decode, map_encode, sum_encoded_size,
+    take_array, write_slice, CompactEncoding, EncodingError, EncodingErrorKind, VecEncodable,
 };
 
 impl CompactEncoding for Node {

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -166,6 +166,8 @@ impl CompactEncoding for DataSeek {
     }
 }
 
+// from:
+// https://github.com/holepunchto/hypercore/blob/d21ebdeca1b27eb4c2232f8af17d5ae939ee97f2/lib/messages.js#L394
 impl CompactEncoding for DataUpgrade {
     fn encoded_size(&self) -> Result<usize, EncodingError> {
         Ok(sum_encoded_size!(
@@ -196,14 +198,14 @@ impl CompactEncoding for DataUpgrade {
         let (length, rest) = u64::decode(rest)?;
         let (nodes, rest) = Vec::<Node>::decode(rest)?;
         let (additional_nodes, rest) = Vec::<Node>::decode(rest)?;
-        let (signature, rest) = <[u8; 32]>::decode(rest)?;
+        let (signature, rest) = <Vec<u8>>::decode(rest)?;
         Ok((
             DataUpgrade {
                 start,
                 length,
                 nodes,
                 additional_nodes,
-                signature: signature.to_vec(),
+                signature,
             },
             rest,
         ))

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -3,9 +3,10 @@ use crate::{
     crypto::{Manifest, ManifestSigner},
     DataBlock, DataHash, DataSeek, DataUpgrade, Node, RequestBlock, RequestSeek, RequestUpgrade,
 };
-use compact_encoding::{as_array, encoded_size_usize, map_encode, sum_encoded_size};
+use compact_encoding::{as_array, encoded_size_usize};
 pub use compact_encoding::{
-    bytes_fixed_from_vec, encode_bytes_fixed, take_array, take_array_mut, write_array, write_slice,
+    bytes_fixed_from_vec, decode_usize, encode_bytes_fixed, map_decode, map_encode,
+    sum_encoded_size, take_array, take_array_mut, to_encoded_bytes, write_array, write_slice,
     CompactEncoding, EncodingError, EncodingErrorKind, VecEncodable,
 };
 

--- a/src/oplog/entry.rs
+++ b/src/oplog/entry.rs
@@ -135,20 +135,20 @@ impl CompactEncoding for Entry {
         };
 
         let (tree_nodes, rest) = if flags & 2 != 0 {
-            <Vec<Node>>::decode(buffer)?
+            <Vec<Node>>::decode(rest)?
         } else {
             (Default::default(), rest)
         };
 
         let (tree_upgrade, rest) = if flags & 2 != 0 {
-            let (x, rest) = EntryTreeUpgrade::decode(buffer)?;
+            let (x, rest) = EntryTreeUpgrade::decode(rest)?;
             (Some(x), rest)
         } else {
             (Default::default(), rest)
         };
 
         let (bitfield, rest) = if flags & 2 != 0 {
-            let (x, rest) = BitfieldUpdate::decode(buffer)?;
+            let (x, rest) = BitfieldUpdate::decode(rest)?;
             (Some(x), rest)
         } else {
             (Default::default(), rest)

--- a/src/oplog/entry.rs
+++ b/src/oplog/entry.rs
@@ -1,9 +1,8 @@
 use compact_encoding::{
-    map_encode, sum_encoded_size, take_array, take_array_mut, write_array, CompactEncoding,
-    EncodingError,
+    map_decode, map_encode, sum_encoded_size, take_array, take_array_mut, write_array,
+    CompactEncoding, EncodingError,
 };
 
-use crate::decode;
 use crate::{common::BitfieldUpdate, Node};
 
 /// Entry tree upgrade
@@ -39,7 +38,17 @@ impl CompactEncoding for EntryTreeUpgrade {
     where
         Self: Sized,
     {
-        decode!(EntryTreeUpgrade, buffer, {fork: u64, ancestors: u64, length: u64, signature: Box<[u8]>})
+        let ((fork, ancestors, length, signature), rest) =
+            map_decode!(buffer, [u64, u64, u64, Box<[u8]>]);
+        Ok((
+            Self {
+                fork,
+                ancestors,
+                length,
+                signature,
+            },
+            rest,
+        ))
     }
 }
 

--- a/src/oplog/entry.rs
+++ b/src/oplog/entry.rs
@@ -62,7 +62,7 @@ impl CompactEncoding for BitfieldUpdate {
 
 /// Oplog Entry
 #[derive(Debug)]
-pub struct Entry {
+pub(crate) struct Entry {
     // TODO: This is a keyValueArray in JS
     pub(crate) user_data: Vec<String>,
     pub(crate) tree_nodes: Vec<Node>,

--- a/src/oplog/entry.rs
+++ b/src/oplog/entry.rs
@@ -68,11 +68,10 @@ impl CompactEncoding for BitfieldUpdate {
         Self: Sized,
     {
         let ([flags], rest) = take_array::<1>(buffer)?;
-        let (start, rest) = u64::decode(rest)?;
-        let (length, rest) = u64::decode(rest)?;
+        let ((start, length), rest) = map_decode!(rest, [u64, u64]);
         Ok((
             BitfieldUpdate {
-                drop: flags == 1,
+                drop: flags & 1 == 1,
                 start,
                 length,
             },

--- a/src/oplog/header.rs
+++ b/src/oplog/header.rs
@@ -285,7 +285,6 @@ mod tests {
         let encoded = to_encoded_bytes!(&key_pair);
         assert_eq!(encoded.len(), expected_len);
         let ((dec_kp,), rest) = map_decode!(&encoded, [PartialKeypair]);
-        dbg!(rest);
         assert!(rest.is_empty());
         assert_eq!(key_pair.public, dec_kp.public);
         assert_eq!(

--- a/src/oplog/header.rs
+++ b/src/oplog/header.rs
@@ -181,8 +181,7 @@ impl CompactEncoding for PartialKeypair {
             // full signing key = secret_key.cocat(public_key)
             FULL_SIGNING_KEY_LENGTH => {
                 let (full_key_bytes, rest) = take_array::<FULL_SIGNING_KEY_LENGTH>(rest)?;
-                let (sk_bytes, _shoul_be_empty) = take_array::<SECRET_KEY_LENGTH>(&full_key_bytes)?;
-                assert!(_shoul_be_empty.is_empty());
+                let (sk_bytes, _pk_bytes) = take_array::<SECRET_KEY_LENGTH>(&full_key_bytes)?;
                 (Some(SigningKey::from_bytes(&sk_bytes)), rest)
             }
             len => {

--- a/src/oplog/header.rs
+++ b/src/oplog/header.rs
@@ -83,6 +83,8 @@ impl HeaderTree {
     }
 }
 
+#[macro_export]
+/// Helper for decoding a struct with compact encodable
 macro_rules! decode {
     // Match the pattern: decode!(StructName, buffer, {field1: type1, field2: type2, ...})
     ($struct_name:ident, $buffer:expr, {

--- a/src/oplog/mod.rs
+++ b/src/oplog/mod.rs
@@ -304,9 +304,6 @@ impl Oplog {
 
         let mut size = len * LEADER_SIZE;
 
-        // TODO:  should I add back the fn sum_encoded_size(&[impl CompactEncoding])-> usize?
-        // it could be used here. I thought there would not be a case where we were encoding a
-        // runtime defined number of types in a row and it not be as a Vec (length prefixed) thing
         for e in batch.iter() {
             size += e.encoded_size()?;
         }

--- a/src/oplog/mod.rs
+++ b/src/oplog/mod.rs
@@ -106,12 +106,15 @@ impl Oplog {
             Some(info) => {
                 let existing = info.data.expect("Could not get data of existing oplog");
                 // First read and validate both headers stored in the existing oplog
-                let h1_outcome = if let Some(h1) = existing.get(OplogSlot::FirstHeader as usize..) {
+                let h1_outcome = if let Some(h1) =
+                    existing.get(OplogSlot::FirstHeader as usize..OplogSlot::SecondHeader as usize)
+                {
                     Self::validate_leader(h1)?
                 } else {
                     None
                 };
-                let h2_outcome = if let Some(h2) = existing.get(OplogSlot::SecondHeader as usize..)
+                let h2_outcome = if let Some(h2) =
+                    existing.get(OplogSlot::SecondHeader as usize..OplogSlot::Entries as usize)
                 {
                     Self::validate_leader(h2)?
                 } else {

--- a/src/oplog/mod.rs
+++ b/src/oplog/mod.rs
@@ -106,12 +106,17 @@ impl Oplog {
             Some(info) => {
                 let existing = info.data.expect("Could not get data of existing oplog");
                 // First read and validate both headers stored in the existing oplog
-                let h1_outcome = Self::validate_leader(
-                    get_slices_checked(&existing, OplogSlot::FirstHeader as usize)?.1,
-                )?;
-                let h2_outcome = Self::validate_leader(
-                    get_slices_checked(&existing, OplogSlot::SecondHeader as usize)?.1,
-                )?;
+                let h1_outcome = if let Some(h1) = existing.get(OplogSlot::FirstHeader as usize..) {
+                    Self::validate_leader(h1)?
+                } else {
+                    None
+                };
+                let h2_outcome = if let Some(h2) = existing.get(OplogSlot::SecondHeader as usize..)
+                {
+                    Self::validate_leader(h2)?
+                } else {
+                    None
+                };
                 // Depending on what is stored, the state needs to be set accordingly.
                 // See `get_next_header_oplog_slot_and_bit_value` for details on header_bits.
                 let mut outcome: OplogOpenOutcome = if let Some(h1_outcome) = h1_outcome {

--- a/src/tree/merkle_tree.rs
+++ b/src/tree/merkle_tree.rs
@@ -662,7 +662,10 @@ impl MerkleTree {
         for (_, node) in self.unflushed.drain() {
             let buffer = (|| {
                 let hash = as_array::<32>(&node.hash)?;
-                Ok::<Vec<u8>, EncodingError>(to_encoded_bytes!(node.length.as_fixed_width(), hash))
+                Ok::<Box<[u8]>, EncodingError>(to_encoded_bytes!(
+                    node.length.as_fixed_width(),
+                    hash
+                ))
             })()
             .expect("Encoding u64 should not fail");
             infos_to_flush.push(StoreInfo::new_content(

--- a/src/tree/merkle_tree.rs
+++ b/src/tree/merkle_tree.rs
@@ -94,7 +94,7 @@ impl MerkleTree {
                 if length > 0 {
                     length /= 2;
                 }
-                let signature: Option<Signature> = if header_tree.signature.len() > 0 {
+                let signature: Option<Signature> = if !header_tree.signature.is_empty() {
                     Some(
                         Signature::try_from(&*header_tree.signature).map_err(|_err| {
                             HypercoreError::InvalidSignature {
@@ -481,11 +481,7 @@ impl MerkleTree {
                     start: upgrade.start,
                     length: upgrade.length,
                     nodes: p.upgrade.expect("nodes need to be set"),
-                    additional_nodes: if let Some(additional_upgrade) = p.additional_upgrade {
-                        additional_upgrade
-                    } else {
-                        vec![]
-                    },
+                    additional_nodes: p.additional_upgrade.unwrap_or_default(),
                     signature: signature
                         .expect("signature needs to be set")
                         .to_bytes()
@@ -1566,7 +1562,7 @@ fn parent_node(index: u64, left: &Node, right: &Node) -> Node {
     )
 }
 
-fn block_node(index: u64, value: &Vec<u8>) -> Node {
+fn block_node(index: u64, value: &[u8]) -> Node {
     Node::new(
         index,
         Hash::data(value).as_bytes().to_vec(),


### PR DESCRIPTION
This updates the crate to use the updated version of the compact encoding crate. The main parts:
*  Rewrites of the `CompactEncoding` implementations. There are a lot of these but they are fairly simple.
* Removes the `HypercoreState` struct. This is no longer needed due to changes to upstream compact encoding. This was used downstream in the `hypercore-protocol` crate (fixed in [this PR](https://github.com/datrs/hypercore-protocol-rs/pull/23)).
* Rewriting of `src/oplog/mod.rs::ValidateLeaderOutcome` this struct heavily used the `HypercoreState` struct so rewriting it was more involved.
* This also removes the re-exports of compact-encoding from `encoding.rs` I believe this was added when the `compact-encoding`  crate was created because `hypercore-protocol` depndended on the encoding code here before it was moved to it's own crate